### PR TITLE
[Feat] 관리자 기능 구현

### DIFF
--- a/src/main/java/com/pickyfy/pickyfy/auth/custom/AdminDetails.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/custom/AdminDetails.java
@@ -1,0 +1,31 @@
+package com.pickyfy.pickyfy.auth.custom;
+
+import com.pickyfy.pickyfy.dto.AdminInfoDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class AdminDetails implements UserDetails {
+
+    private final AdminInfoDto adminInfoDto;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return adminInfoDto.password();
+    }
+
+    @Override
+    public String getUsername() {
+        return adminInfoDto.name();
+    }
+
+}

--- a/src/main/java/com/pickyfy/pickyfy/auth/custom/CustomUserDetailsService.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/custom/CustomUserDetailsService.java
@@ -1,7 +1,10 @@
 package com.pickyfy.pickyfy.auth.custom;
 
+import com.pickyfy.pickyfy.domain.Admin;
 import com.pickyfy.pickyfy.domain.User;
+import com.pickyfy.pickyfy.dto.AdminInfoDto;
 import com.pickyfy.pickyfy.dto.CustomUserInfoDto;
+import com.pickyfy.pickyfy.repository.AdminRepository;
 import com.pickyfy.pickyfy.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,17 +20,20 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     private final static String NOT_FOUND_USER = "해당하는 유저가 없습니다.";
 
+    private final AdminRepository adminRepository;
     private final UserRepository userRepository;
 
+    // admin 로드
     @Override
-    public UserDetails loadUserByUsername(String nickname) throws UsernameNotFoundException {
-        User user = userRepository.findByNickname(nickname)
+    public UserDetails loadUserByUsername(String name) throws UsernameNotFoundException {
+        Admin admin = adminRepository.findByName(name)
                 .orElseThrow(() -> new UsernameNotFoundException(NOT_FOUND_USER));
-        CustomUserInfoDto customUserInfoDto = CustomUserInfoDto.from(user);
+        AdminInfoDto adminInfoDto = AdminInfoDto.from(admin);
 
-        return new CustomUserDetails(customUserInfoDto);
+        return new AdminDetails(adminInfoDto);
     }
 
+    // 일반 유저 로드
     public UserDetails loadUserByEmail(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException(NOT_FOUND_USER));

--- a/src/main/java/com/pickyfy/pickyfy/auth/filter/JwtAdminAuthFilter.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/filter/JwtAdminAuthFilter.java
@@ -1,0 +1,78 @@
+package com.pickyfy.pickyfy.auth.filter;
+
+import com.pickyfy.pickyfy.auth.custom.AdminDetails;
+import com.pickyfy.pickyfy.auth.custom.CustomUserDetailsService;
+import com.pickyfy.pickyfy.auth.util.AuthorityConstant;
+import com.pickyfy.pickyfy.auth.util.JwtAdminUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAdminAuthFilter extends OncePerRequestFilter implements JwtAuthFilter {
+
+    private static final String REQUIRED_ROLE = "ROLE_ADMIN";
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtAdminUtil jwtAdminUtil;
+
+    @Override
+    public void doFilterInternal(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+        // 토큰 인증이 안 된 경우에는 다음 필터 체인으로 넘어가도록
+        if (token == null || !jwtAdminUtil.validateToken(token)){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String adminName = jwtAdminUtil.getAdminName(token);
+        AdminDetails adminDetails = loadAdminDetails(adminName);
+
+        // 권한 부족인 경우에는 그냥 체인 중단시켜버림
+        if (adminDetails == null || !hasRequiredRole(adminDetails)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "거부된 관리자 권한입니다.");
+            return;
+        }
+
+        setAuthentication(adminDetails);
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    public String resolveToken(HttpServletRequest request){
+        String authorizationHeader = request.getHeader(AuthorityConstant.ACCESS_TOKEN_HEADER);
+        if (authorizationHeader != null && authorizationHeader.startsWith(AuthorityConstant.BEARER_PREFIX)){
+            return authorizationHeader.substring(AuthorityConstant.BEARER_LENGTH);
+        }
+        return null;
+    }
+
+    private AdminDetails loadAdminDetails(String adminName){
+        try{
+            return (AdminDetails) customUserDetailsService.loadUserByUsername(adminName);
+        } catch (UsernameNotFoundException e){
+            return null;
+        }
+    }
+
+    private boolean hasRequiredRole(AdminDetails adminDetails){
+        return adminDetails.getAuthorities().stream()
+                .anyMatch(authority -> authority.getAuthority().equals(REQUIRED_ROLE));
+    }
+
+    private void setAuthentication(AdminDetails adminDetails){
+        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                new UsernamePasswordAuthenticationToken(adminDetails, null, adminDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+    }
+}

--- a/src/main/java/com/pickyfy/pickyfy/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/filter/JwtAuthFilter.java
@@ -1,55 +1,16 @@
 package com.pickyfy.pickyfy.auth.filter;
 
-import com.pickyfy.pickyfy.auth.util.JwtUtil;
-import com.pickyfy.pickyfy.auth.custom.CustomUserDetails;
-import com.pickyfy.pickyfy.auth.custom.CustomUserDetailsService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-@RequiredArgsConstructor
-public class JwtAuthFilter extends OncePerRequestFilter {
+public interface JwtAuthFilter {
 
-    private static final String ACCESS_TOKEN_HEADER = "Authorization";
-    private static final String BEARER = "Bearer ";
+    void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException;
 
-    private final CustomUserDetailsService customUserDetailsService;
-    private final JwtUtil jwtUtil;
+    String resolveToken(HttpServletRequest request);
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
-
-        String authorizationHeader = request.getHeader(ACCESS_TOKEN_HEADER);
-
-        if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-        String token = authorizationHeader.substring(7);
-
-        if (!jwtUtil.validateToken(token)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-        String email = jwtUtil.getUserEmail(token);
-        CustomUserDetails userDetails = (CustomUserDetails) customUserDetailsService.loadUserByEmail(email);
-
-        if (userDetails == null) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
-
-        filterChain.doFilter(request, response);
-    }
 }

--- a/src/main/java/com/pickyfy/pickyfy/auth/filter/JwtUserAuthFilter.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/filter/JwtUserAuthFilter.java
@@ -1,0 +1,80 @@
+package com.pickyfy.pickyfy.auth.filter;
+
+import com.pickyfy.pickyfy.auth.custom.CustomUserDetails;
+import com.pickyfy.pickyfy.auth.custom.CustomUserDetailsService;
+import com.pickyfy.pickyfy.auth.util.AuthorityConstant;
+import com.pickyfy.pickyfy.auth.util.JwtUserUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtUserAuthFilter extends OncePerRequestFilter implements JwtAuthFilter {
+
+    private static final String REQUIRED_ROLE = "ROLE_USER";
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUserUtil jwtUserUtil;
+
+    @Override
+    public void doFilterInternal(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+        if (token == null || !jwtUserUtil.validateToken(token)){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String email = jwtUserUtil.getUserEmail(token);
+        CustomUserDetails userDetails = loadUserDetails(email);
+
+        if (userDetails == null){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (!hasRequiredRole(userDetails)){
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "거부된 사용자 권한입니다.");
+            return;
+        }
+
+        setAuthentication(userDetails);
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    public String resolveToken(HttpServletRequest request){
+        String authorizationHeader = request.getHeader(AuthorityConstant.ACCESS_TOKEN_HEADER);
+        if (authorizationHeader == null || !authorizationHeader.startsWith(AuthorityConstant.BEARER_PREFIX)){
+            return null;
+        }
+        return authorizationHeader.substring(AuthorityConstant.BEARER_LENGTH); // bearer 이후 부분 차출
+    }
+
+    private CustomUserDetails loadUserDetails(String email){
+        try{
+            return (CustomUserDetails) customUserDetailsService.loadUserByEmail(email);
+        } catch (UsernameNotFoundException e){
+            return null;
+        }
+    }
+
+    private boolean hasRequiredRole(CustomUserDetails userDetails){
+        return userDetails.getAuthorities().stream()
+                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals(REQUIRED_ROLE));
+    }
+
+    private void setAuthentication(CustomUserDetails userDetails){
+        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+    }
+}

--- a/src/main/java/com/pickyfy/pickyfy/auth/util/AuthorityConstant.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/util/AuthorityConstant.java
@@ -1,0 +1,8 @@
+package com.pickyfy.pickyfy.auth.util;
+
+public class AuthorityConstant {
+
+    public static final String ACCESS_TOKEN_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+    public static final int BEARER_LENGTH = 7;
+}

--- a/src/main/java/com/pickyfy/pickyfy/auth/util/JwtAdminUtil.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/util/JwtAdminUtil.java
@@ -1,0 +1,78 @@
+package com.pickyfy.pickyfy.auth.util;
+
+import com.pickyfy.pickyfy.dto.AdminInfoDto;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtAdminUtil {
+    private static final String NAME = "name";
+
+    private final Key key;
+    private final long accessTokenExpTime;
+
+    public JwtAdminUtil(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.expiration_time}") long accessTokenExpTime
+    ) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpTime = accessTokenExpTime;
+    }
+
+    public String createAccessToken(AdminInfoDto adminInfoDto) {
+        return createToken(adminInfoDto, accessTokenExpTime);
+    }
+
+    private String createToken(AdminInfoDto adminInfoDto, long expireTime) {
+        String email = adminInfoDto.name();
+
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime tokenValidity = now.plusSeconds(expireTime);
+
+        return Jwts.builder()
+                .claim(NAME, email)
+                .issuedAt(Date.from(now.toInstant()))
+                .expiration(Date.from(tokenValidity.toInstant()))
+                .signWith(key)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().verifyWith((SecretKey) key).build().parseSignedClaims(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("잘못된 서명 혹은 JWT 형식 오류", e);
+        } catch (ExpiredJwtException e) {
+            log.info("토큰 만료", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("지원하지 않는 서명 알고리즘", e);
+        } catch (IllegalArgumentException e) {
+            log.info("올바르지 않은 값 입력(토큰 문자열 null)", e);
+        }
+        return false;
+    }
+
+    public Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parser().verifyWith((SecretKey) key).build().parseSignedClaims(accessToken).getPayload();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    public String getAdminName(String token) {
+        return parseClaims(token).get(NAME, String.class);
+    }
+}

--- a/src/main/java/com/pickyfy/pickyfy/auth/util/JwtUserUtil.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/util/JwtUserUtil.java
@@ -14,14 +14,13 @@ import java.util.Date;
 
 @Slf4j
 @Component
-public class JwtUtil {
-
+public class JwtUserUtil {
     private static final String EMAIL = "email";
 
     private final Key key;
     private final long accessTokenExpTime;
 
-    public JwtUtil(
+    public JwtUserUtil(
             @Value("${jwt.secret}") String secretKey,
             @Value("${jwt.expiration_time}") long accessTokenExpTime
     ) {

--- a/src/main/java/com/pickyfy/pickyfy/config/SecurityConfig.java
+++ b/src/main/java/com/pickyfy/pickyfy/config/SecurityConfig.java
@@ -1,7 +1,9 @@
 package com.pickyfy.pickyfy.config;
 
-import com.pickyfy.pickyfy.auth.filter.JwtAuthFilter;
-import com.pickyfy.pickyfy.auth.util.JwtUtil;
+import com.pickyfy.pickyfy.auth.filter.JwtAdminAuthFilter;
+import com.pickyfy.pickyfy.auth.filter.JwtUserAuthFilter;
+import com.pickyfy.pickyfy.auth.util.JwtAdminUtil;
+import com.pickyfy.pickyfy.auth.util.JwtUserUtil;
 import com.pickyfy.pickyfy.auth.custom.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -21,7 +23,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final CustomUserDetailsService customUserDetailsService;
-    private final JwtUtil jwtUtil;
+    private final JwtAdminUtil jwtAdminUtil;
+    private final JwtUserUtil jwtUserUtil;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
@@ -40,7 +43,8 @@ public class SecurityConfig {
                         .anyRequest().authenticated());
 
         http
-                .addFilterBefore(new JwtAuthFilter(customUserDetailsService, jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtUserAuthFilter(customUserDetailsService, jwtUserUtil), JwtUserAuthFilter.class)
+                .addFilterBefore(new JwtAdminAuthFilter(customUserDetailsService, jwtAdminUtil), JwtAdminAuthFilter.class);
         return http.build();
     }
 

--- a/src/main/java/com/pickyfy/pickyfy/domain/Admin.java
+++ b/src/main/java/com/pickyfy/pickyfy/domain/Admin.java
@@ -1,0 +1,29 @@
+package com.pickyfy.pickyfy.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Admin extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Builder
+    public Admin(String name, String password){
+        this.name = name;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/pickyfy/pickyfy/dto/AdminInfoDto.java
+++ b/src/main/java/com/pickyfy/pickyfy/dto/AdminInfoDto.java
@@ -1,0 +1,15 @@
+package com.pickyfy.pickyfy.dto;
+
+import com.pickyfy.pickyfy.domain.Admin;
+import lombok.Builder;
+
+@Builder
+public record AdminInfoDto(String name, String password) {
+
+    public static AdminInfoDto from(Admin admin) {
+        return AdminInfoDto.builder()
+                .name(admin.getName())
+                .password(admin.getPassword())
+                .build();
+    }
+}

--- a/src/main/java/com/pickyfy/pickyfy/repository/AdminRepository.java
+++ b/src/main/java/com/pickyfy/pickyfy/repository/AdminRepository.java
@@ -1,11 +1,11 @@
 package com.pickyfy.pickyfy.repository;
 
-import com.pickyfy.pickyfy.domain.User;
+import com.pickyfy.pickyfy.domain.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface AdminRepository extends JpaRepository<User, Long> {
+public interface AdminRepository extends JpaRepository<Admin, Long> {
 
-    Optional<User> findByName(String name);
+    Optional<Admin> findByName(String name);
 }

--- a/src/main/java/com/pickyfy/pickyfy/repository/AdminRepository.java
+++ b/src/main/java/com/pickyfy/pickyfy/repository/AdminRepository.java
@@ -1,0 +1,11 @@
+package com.pickyfy.pickyfy.repository;
+
+import com.pickyfy.pickyfy.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AdminRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByName(String name);
+}


### PR DESCRIPTION
## 1. JwtAuthFilter 인터페이스 생성
- JwtAdminAuthFilter와 JwtUserAuthFilter가 이를 구현

---

## 2. JwtUserAuthFilter 리팩터링 + 관리자 기능과 분리
- 책임분리를 위해 한 메서드에 있었던 기능들을 다른 메서드들로 분리(약 4개의 메서드 추가)
- 일반 유저와 관리자는 role(역할)로 구분
- 이는 SecurityConfig에 관리자 관련 필터 체인을 추가하여 역할에 따라 필터링할 수 있도록 구현
- 로그인 시 부여되지 않은 권한인 경우에는 다음 필터로 넘어가지 않고 그냥 중간에 중단되도록 리팩토링함(단 단순 토큰 인증 불가인 경우에는 다음 필터로 넘어가도록 함)
- 에러 관련 처리는 아직

---

## 3. 권한 검증 관련 상수 클래스(AuthorityConstant) 생성

---

## 4. 고민
(1) 클래스명들이 너무 헷갈림
   - CustomUserDetailService에 일반 유저와 관리자 처리 관련 로직이 모두 들어있음
   - 그 내부 메서드들명도 이름만으로는 일반 유저 or 관리자 처리 로직인지 구분 불가(loadUserByUsername, loadUserByEmail) -> UserDetailsService를 그냥 커스텀할까 생각중
   - Util이 붙어있는 클래스명도 어떤 목적을 가진 클래스인지 네이밍을 다시 하면 어떨까

(2) 위에서 말한 대로 CustomUserDetailsService가 구현하는 UserDetailsService를 커스텀해서 더 직관적으로 만들까
  - 우선 다른 방법이 있는지는 찾아보지 않았음

(3) AdminDetails와 CustomUserDetails의 인터페이스를 만들까
  - 만들면 장점: JwtAuthFilter 인터페이스에 오버라이딩을 강제할 공통 메서드를 더 생성할 수 있음(지금은 각 필터에서 AdminDetails, CustomUserDetails를 각각 파라미터로 받고 있기 때문에)

---

에러 관련 처리 아직
컨트롤러 구현 아직

**🚨 리팩토링하다가 내가 잘못 바꾼 부분이 있을 수 있으니 확인하고 알려주세요**