### PR TITLE
feature/#29 매거진 CRUD 작성

### DIFF
--- a/src/main/java/com/pickyfy/pickyfy/domain/Magazine.java
+++ b/src/main/java/com/pickyfy/pickyfy/domain/Magazine.java
@@ -26,6 +26,9 @@ public class Magazine extends BaseTimeEntity {
     @Column(nullable = false)
     private String title;
 
+    @Column
+    private String iconUrl;
+
     @Column(nullable = false)
     private String content;
 
@@ -33,8 +36,9 @@ public class Magazine extends BaseTimeEntity {
     private List<PlaceMagazine> placeMagazines = new ArrayList<>();
 
     @Builder
-    public Magazine(String title, String content) {
+    public Magazine(String title,String iconUrl, String content) {
         this.title = title;
+        this.iconUrl = iconUrl;
         this.content = content;
     }
 }

--- a/src/main/java/com/pickyfy/pickyfy/domain/Magazine.java
+++ b/src/main/java/com/pickyfy/pickyfy/domain/Magazine.java
@@ -41,4 +41,13 @@ public class Magazine extends BaseTimeEntity {
         this.iconUrl = iconUrl;
         this.content = content;
     }
+
+    /**
+     * 비즈니스 메소드
+     */
+    public void update(String title, String iconUrl, String content) {
+        this.title = title;
+        this.iconUrl = iconUrl;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/pickyfy/pickyfy/repository/MagazineRepository.java
+++ b/src/main/java/com/pickyfy/pickyfy/repository/MagazineRepository.java
@@ -1,0 +1,7 @@
+package com.pickyfy.pickyfy.repository;
+
+import com.pickyfy.pickyfy.domain.Magazine;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MagazineRepository extends JpaRepository<Magazine, Long> {
+}

--- a/src/main/java/com/pickyfy/pickyfy/repository/MagazineRepository.java
+++ b/src/main/java/com/pickyfy/pickyfy/repository/MagazineRepository.java
@@ -4,4 +4,5 @@ import com.pickyfy.pickyfy.domain.Magazine;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
+    boolean existsByTitle(String title);
 }

--- a/src/main/java/com/pickyfy/pickyfy/service/MagazineService.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/MagazineService.java
@@ -1,0 +1,14 @@
+package com.pickyfy.pickyfy.service;
+
+import com.pickyfy.pickyfy.web.dto.request.MagazineCreateRequest;
+import com.pickyfy.pickyfy.web.dto.request.MagazineUpdateRequest;
+import com.pickyfy.pickyfy.web.dto.response.MagazineResponse;
+import java.util.List;
+
+public interface MagazineService {
+    Long createMagazine(MagazineCreateRequest request);
+    MagazineResponse getMagazine(Long id);
+    List<MagazineResponse> getAllMagazines();
+    void updateMagazine(Long id, MagazineUpdateRequest request);
+    void deleteMagazine(Long id);
+}

--- a/src/main/java/com/pickyfy/pickyfy/service/MagazineServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/MagazineServiceImpl.java
@@ -2,6 +2,7 @@ package com.pickyfy.pickyfy.service;
 
 import com.pickyfy.pickyfy.apiPayload.code.status.ErrorStatus;
 import com.pickyfy.pickyfy.domain.Magazine;
+import com.pickyfy.pickyfy.exception.DuplicateResourceException;
 import com.pickyfy.pickyfy.repository.MagazineRepository;
 import com.pickyfy.pickyfy.web.dto.request.MagazineCreateRequest;
 import com.pickyfy.pickyfy.web.dto.request.MagazineUpdateRequest;
@@ -23,6 +24,7 @@ public class MagazineServiceImpl implements MagazineService {
     @Override
     @Transactional
     public Long createMagazine(MagazineCreateRequest request) {
+        validateDuplicateTitle(request.title());
         Magazine magazine = Magazine.builder()
                 .title(request.title())
                 .iconUrl(request.iconUrl())
@@ -63,5 +65,11 @@ public class MagazineServiceImpl implements MagazineService {
         return magazineRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(
                         ErrorStatus.MAGAZINE_NOT_FOUND.getMessage() + ": " + id));
+    }
+
+    private void validateDuplicateTitle(String title) {
+        if (magazineRepository.existsByTitle(title)) {
+            throw new DuplicateResourceException(ErrorStatus.CATEGORY_DUPLICATED);
+        }
     }
 }

--- a/src/main/java/com/pickyfy/pickyfy/service/MagazineServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/MagazineServiceImpl.java
@@ -1,0 +1,67 @@
+package com.pickyfy.pickyfy.service;
+
+import com.pickyfy.pickyfy.apiPayload.code.status.ErrorStatus;
+import com.pickyfy.pickyfy.domain.Magazine;
+import com.pickyfy.pickyfy.repository.MagazineRepository;
+import com.pickyfy.pickyfy.web.dto.request.MagazineCreateRequest;
+import com.pickyfy.pickyfy.web.dto.request.MagazineUpdateRequest;
+import com.pickyfy.pickyfy.web.dto.response.MagazineResponse;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MagazineServiceImpl implements MagazineService {
+
+    private final MagazineRepository magazineRepository;
+
+    @Override
+    @Transactional
+    public Long createMagazine(MagazineCreateRequest request) {
+        Magazine magazine = Magazine.builder()
+                .title(request.title())
+                .iconUrl(request.iconUrl())
+                .content(request.content())
+                .build();
+
+        return magazineRepository.save(magazine).getId();
+    }
+
+    @Override
+    public MagazineResponse getMagazine(Long id) {
+        Magazine magazine = findMagazineById(id);
+        return MagazineResponse.from(magazine);
+    }
+
+    @Override
+    public List<MagazineResponse> getAllMagazines() {
+        return magazineRepository.findAll().stream()
+                .map(MagazineResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void updateMagazine(Long id, MagazineUpdateRequest request) {
+        Magazine magazine = findMagazineById(id);
+        magazine.update(request.title(), request.iconUrl(), request.content());
+    }
+
+    @Override
+    @Transactional
+    public void deleteMagazine(Long id) {
+        Magazine magazine = findMagazineById(id);
+        magazineRepository.delete(magazine);
+    }
+
+    private Magazine findMagazineById(Long id) {
+        return magazineRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        ErrorStatus.MAGAZINE_NOT_FOUND.getMessage() + ": " + id));
+    }
+}

--- a/src/main/java/com/pickyfy/pickyfy/web/controller/MagazineController.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/controller/MagazineController.java
@@ -1,0 +1,58 @@
+package com.pickyfy.pickyfy.web.controller;
+
+import com.pickyfy.pickyfy.apiPayload.ApiResponse;
+import com.pickyfy.pickyfy.service.MagazineService;
+import com.pickyfy.pickyfy.web.dto.request.MagazineCreateRequest;
+import com.pickyfy.pickyfy.web.dto.request.MagazineUpdateRequest;
+import com.pickyfy.pickyfy.web.dto.response.MagazineResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MagazineController implements MagazineControllerApi {
+
+    private final MagazineService magazineService;
+
+    @PostMapping("/admin/magazines")
+    public ApiResponse<Long> createMagazine(@Valid @RequestBody MagazineCreateRequest request) {
+        Long magazineId = magazineService.createMagazine(request);
+        return ApiResponse.onSuccess(magazineId);
+    }
+
+    @GetMapping("/magazines/{id}")
+    public ApiResponse<MagazineResponse> getMagazine(@PathVariable Long id) {
+        MagazineResponse response = magazineService.getMagazine(id);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/magazines")
+    public ApiResponse<List<MagazineResponse>> getAllMagazines() {
+        List<MagazineResponse> responses = magazineService.getAllMagazines();
+        return ApiResponse.onSuccess(responses);
+    }
+
+    @PutMapping("/admin/magazines/{id}")
+    public ApiResponse<Long> updateMagazine(
+            @PathVariable Long id,
+            @Valid @RequestBody MagazineUpdateRequest request) {
+        magazineService.updateMagazine(id, request);
+        return ApiResponse.onSuccess(id);
+    }
+
+    @DeleteMapping("/admin/magazines/{id}")
+    public ApiResponse<Long> deleteMagazine(@PathVariable Long id) {
+        magazineService.deleteMagazine(id);
+        return ApiResponse.onSuccess(id);
+    }
+}

--- a/src/main/java/com/pickyfy/pickyfy/web/controller/MagazineControllerApi.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/controller/MagazineControllerApi.java
@@ -1,0 +1,123 @@
+package com.pickyfy.pickyfy.web.controller;
+
+import com.pickyfy.pickyfy.apiPayload.ApiResponse;
+import com.pickyfy.pickyfy.web.dto.request.MagazineCreateRequest;
+import com.pickyfy.pickyfy.web.dto.request.MagazineUpdateRequest;
+import com.pickyfy.pickyfy.web.dto.response.MagazineResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "매거진", description = "매거진 관련 API")
+public interface MagazineControllerApi {
+
+    @Operation(
+            summary = "매거진 생성 API",
+            description = "관리자용 매거진 생성 API입니다. 제목, 아이콘 URL, 내용을 입력받아 새로운 매거진을 생성합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "COMMON200",
+                    description = "OK, 성공",
+                    content = @Content(schema = @Schema(implementation = Long.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "ERROR400",
+                    description = "잘못된 요청"
+            )
+    })
+    @PostMapping("/admin/magazines")
+    ApiResponse<Long> createMagazine(
+            @Parameter(description = "매거진 생성 정보", required = true)
+            @Valid @RequestBody MagazineCreateRequest request
+    );
+
+    @Operation(
+            summary = "매거진 조회 API",
+            description = "특정 ID의 매거진을 조회하는 API입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "COMMON200",
+                    description = "OK, 성공",
+                    content = @Content(schema = @Schema(implementation = MagazineResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "ERROR404",
+                    description = "매거진을 찾을 수 없음"
+            )
+    })
+    @GetMapping("/magazines/{id}")
+    ApiResponse<MagazineResponse> getMagazine(
+            @Parameter(description = "매거진 ID", required = true)
+            @PathVariable Long id
+    );
+
+    @Operation(
+            summary = "전체 매거진 조회 API",
+            description = "모든 매거진을 조회하는 API입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "COMMON200",
+                    description = "OK, 성공",
+                    content = @Content(schema = @Schema(implementation = List.class))
+            )
+    })
+    @GetMapping("/magazines")
+    ApiResponse<List<MagazineResponse>> getAllMagazines();
+
+    @Operation(
+            summary = "매거진 수정 API",
+            description = "관리자용 매거진 수정 API입니다. 제목, 아이콘 URL, 내용을 수정할 수 있습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "COMMON200",
+                    description = "OK, 성공",
+                    content = @Content(schema = @Schema(implementation = Long.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "ERROR400",
+                    description = "잘못된 요청"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "ERROR404",
+                    description = "매거진을 찾을 수 없음"
+            )
+    })
+    @PutMapping("/admin/magazines/{id}")
+    ApiResponse<Long> updateMagazine(
+            @Parameter(description = "매거진 ID", required = true)
+            @PathVariable Long id,
+            @Parameter(description = "매거진 수정 정보", required = true)
+            @Valid @RequestBody MagazineUpdateRequest request
+    );
+
+    @Operation(
+            summary = "매거진 삭제 API",
+            description = "관리자용 매거진 삭제 API입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "COMMON200",
+                    description = "OK, 성공",
+                    content = @Content(schema = @Schema(implementation = Long.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "ERROR404",
+                    description = "매거진을 찾을 수 없음"
+            )
+    })
+    @DeleteMapping("/admin/magazines/{id}")
+    ApiResponse<Long> deleteMagazine(
+            @Parameter(description = "매거진 ID", required = true)
+            @PathVariable Long id
+    );
+}

--- a/src/main/java/com/pickyfy/pickyfy/web/dto/request/MagazineCreateRequest.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/dto/request/MagazineCreateRequest.java
@@ -1,0 +1,13 @@
+package com.pickyfy.pickyfy.web.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MagazineCreateRequest(
+        @NotBlank(message = "제목은 필수입니다")
+        String title,
+
+        String iconUrl,  // 선택적 필드
+
+        @NotBlank(message = "내용은 필수입니다")
+        String content
+) {}

--- a/src/main/java/com/pickyfy/pickyfy/web/dto/request/MagazineUpdateRequest.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/dto/request/MagazineUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.pickyfy.pickyfy.web.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MagazineUpdateRequest(
+        @NotBlank(message = "제목은 필수입니다")
+        String title,
+
+        String iconUrl,
+
+        @NotBlank(message = "내용은 필수입니다")
+        String content
+) {}

--- a/src/main/java/com/pickyfy/pickyfy/web/dto/response/MagazineResponse.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/dto/response/MagazineResponse.java
@@ -1,0 +1,22 @@
+package com.pickyfy.pickyfy.web.dto.response;
+
+import com.pickyfy.pickyfy.domain.Magazine;
+import java.time.LocalDateTime;
+
+public record MagazineResponse(
+        Long id,
+        String title,
+        String iconUrl,
+        String content,
+        LocalDateTime createdAt
+) {
+    public static MagazineResponse from(Magazine magazine) {
+        return new MagazineResponse(
+                magazine.getId(),
+                magazine.getTitle(),
+                magazine.getIconUrl(),
+                magazine.getContent(),
+                magazine.getCreatedAt()
+        );
+    }
+}

--- a/src/test/java/com/pickyfy/pickyfy/service/MagazineServiceImplTest.java
+++ b/src/test/java/com/pickyfy/pickyfy/service/MagazineServiceImplTest.java
@@ -1,0 +1,169 @@
+package com.pickyfy.pickyfy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.pickyfy.pickyfy.domain.Magazine;
+import com.pickyfy.pickyfy.repository.MagazineRepository;
+import com.pickyfy.pickyfy.web.dto.request.MagazineCreateRequest;
+import com.pickyfy.pickyfy.web.dto.request.MagazineUpdateRequest;
+import com.pickyfy.pickyfy.web.dto.response.MagazineResponse;
+import jakarta.persistence.EntityNotFoundException;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MagazineServiceImplTest {
+
+    @Mock
+    private MagazineRepository magazineRepository;
+
+    @InjectMocks
+    private MagazineServiceImpl magazineService;
+
+    private Magazine magazine;
+
+    @BeforeEach
+    void setUp() throws NoSuchFieldException, IllegalAccessException {
+        magazine = Magazine.builder()
+                .title("테스트 매거진")
+                .iconUrl("test-icon.png")
+                .content("테스트 내용입니다.")
+                .build();
+
+        // Reflection을 사용해 id 설정
+        Field idField = Magazine.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(magazine, 1L);
+    }
+
+    @Test
+    void createMagazine_Success() {
+        // Given
+        MagazineCreateRequest request = new MagazineCreateRequest(
+                "테스트 매거진",
+                "test-icon.png",
+                "테스트 내용입니다."
+        );
+        given(magazineRepository.save(any(Magazine.class))).willReturn(magazine);
+
+        // When
+        Long magazineId = magazineService.createMagazine(request);
+
+        // Then
+        assertThat(magazineId).isEqualTo(1L);
+        verify(magazineRepository).save(any(Magazine.class));
+    }
+
+    @Test
+    void getMagazine_Success() {
+        // Given
+        given(magazineRepository.findById(1L)).willReturn(Optional.of(magazine));
+
+        // When
+        MagazineResponse response = magazineService.getMagazine(1L);
+
+        // Then
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.title()).isEqualTo("테스트 매거진");
+        assertThat(response.iconUrl()).isEqualTo("test-icon.png");
+        assertThat(response.content()).isEqualTo("테스트 내용입니다.");
+    }
+
+    @Test
+    void getMagazine_NotFound_ThrowsException() {
+        // Given
+        given(magazineRepository.findById(1L)).willReturn(Optional.empty());
+
+        // When/Then
+        assertThatThrownBy(() -> magazineService.getMagazine(1L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining(String.valueOf(1L));
+    }
+
+    @Test
+    void getAllMagazines_Success() {
+        // Given
+        List<Magazine> magazines = List.of(magazine);
+        given(magazineRepository.findAll()).willReturn(magazines);
+
+        // When
+        List<MagazineResponse> responses = magazineService.getAllMagazines();
+
+        // Then
+        assertThat(responses).hasSize(1);
+        MagazineResponse response = responses.get(0);
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.title()).isEqualTo("테스트 매거진");
+        assertThat(response.iconUrl()).isEqualTo("test-icon.png");
+        assertThat(response.content()).isEqualTo("테스트 내용입니다.");
+    }
+
+    @Test
+    void updateMagazine_Success() {
+        // Given
+        MagazineUpdateRequest request = new MagazineUpdateRequest(
+                "수정된 매거진",
+                "updated-icon.png",
+                "수정된 내용입니다."
+        );
+        given(magazineRepository.findById(1L)).willReturn(Optional.of(magazine));
+
+        // When
+        magazineService.updateMagazine(1L, request);
+
+        // Then
+        assertThat(magazine.getTitle()).isEqualTo("수정된 매거진");
+        assertThat(magazine.getIconUrl()).isEqualTo("updated-icon.png");
+        assertThat(magazine.getContent()).isEqualTo("수정된 내용입니다.");
+    }
+
+    @Test
+    void updateMagazine_NotFound_ThrowsException() {
+        // Given
+        MagazineUpdateRequest request = new MagazineUpdateRequest(
+                "수정된 매거진",
+                "updated-icon.png",
+                "수정된 내용입니다."
+        );
+        given(magazineRepository.findById(1L)).willReturn(Optional.empty());
+
+        // When/Then
+        assertThatThrownBy(() -> magazineService.updateMagazine(1L, request))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining(String.valueOf(1L));
+    }
+
+    @Test
+    void deleteMagazine_Success() {
+        // Given
+        given(magazineRepository.findById(1L)).willReturn(Optional.of(magazine));
+
+        // When
+        magazineService.deleteMagazine(1L);
+
+        // Then
+        verify(magazineRepository).delete(magazine);
+    }
+
+    @Test
+    void deleteMagazine_NotFound_ThrowsException() {
+        // Given
+        given(magazineRepository.findById(1L)).willReturn(Optional.empty());
+
+        // When/Then
+        assertThatThrownBy(() -> magazineService.deleteMagazine(1L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining(String.valueOf(1L));
+    }
+}


### PR DESCRIPTION
## 📝작업 내용

> 메거진에 대한 CRUD 기능 구현

## 💬리뷰 요구사항(선택)

#### admin 계정이 필요한 기능은 url로 구분하였습니다.

#### 관리자 페이지에도 에러 Status를 클라이언트로 내려주도록 구현하였습니다.
- 추후 데이터 수집 작업 시 여러 관리자가 관리자 페이지를 사용할 텐데 클라리언트 측에서 에러 발생 시 즉각적으로 알아야 하기 때문입니다.
- 관리자 API도 명백한 API이므로 기존에 잘 만들어 둔 통신 규약을 굳이 이용하지 않을 이유는 없다고 생각합니다.