### PR TITLE
[refactor] 매거진 관련 기능 uri에 "/api" 제거

### DIFF
--- a/src/main/java/com/pickyfy/pickyfy/web/controller/MagazineController.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/controller/MagazineController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/")
 @RequiredArgsConstructor
 public class MagazineController implements MagazineControllerApi {
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #39

## 📝작업 내용

> uri에 api 제거

## 💬리뷰 요구사항(선택)

> 실수로 매거진 API의 URI를 "/api/~~" 형식으로 작성하여, 일반 유저와 어드민이 구별되지 않습니다.. 
> 하지만 아무도 알아차리지 못 하였기 때문에 빠르게 수정을 하겠습니다. 모른 척 해주세요..
