### PR TITLE
[Fix] CORS 설정 allowedOrigins -> allowedOriginsPattern 변경

### DIFF
--- a/src/main/java/com/pickyfy/pickyfy/config/WebConfig.java
+++ b/src/main/java/com/pickyfy/pickyfy/config/WebConfig.java
@@ -16,7 +16,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("*")
+                .allowedOriginPatterns("*")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
                 .allowedHeaders("*")
                 .allowCredentials(true)


### PR DESCRIPTION
allowCredentials(true) 설정으로 인해 CORS 오류 수정

- allowedOrigins("*") 사용 시 IllegalArgumentException 발생
- allowedOriginsPattern("*")으로 변경하여 문제 해결