### PR TITLE
[bug] 매거진 정보 변경 로직 변경

### DIFF
--- a/src/main/java/com/pickyfy/pickyfy/service/MagazineServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/MagazineServiceImpl.java
@@ -51,6 +51,10 @@ public class MagazineServiceImpl implements MagazineService {
     @Transactional
     public void updateMagazine(Long id, MagazineUpdateRequest request) {
         Magazine magazine = findMagazineById(id);
+        if (request.iconFile() == null){
+            magazine.update(request.title());
+            return;
+        }
         magazine.update(request.title(), s3Service.upload(request.iconFile()));
     }
 

--- a/src/main/java/com/pickyfy/pickyfy/service/MagazineServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/MagazineServiceImpl.java
@@ -55,7 +55,11 @@ public class MagazineServiceImpl implements MagazineService {
             magazine.update(request.title());
             return;
         }
+        String oldIconUrl = magazine.getIconUrl();
         magazine.update(request.title(), s3Service.upload(request.iconFile()));
+        if (oldIconUrl != null && !oldIconUrl.isEmpty()) {
+            s3Service.removeFile(oldIconUrl);
+        }
     }
 
     @Override

--- a/src/test/java/com/pickyfy/pickyfy/service/MagazineServiceImplTest.java
+++ b/src/test/java/com/pickyfy/pickyfy/service/MagazineServiceImplTest.java
@@ -5,10 +5,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.pickyfy.pickyfy.domain.Magazine;
 import com.pickyfy.pickyfy.repository.MagazineRepository;
 import com.pickyfy.pickyfy.web.dto.request.MagazineCreateRequest;
+import com.pickyfy.pickyfy.web.dto.request.MagazineUpdateRequest;
 import com.pickyfy.pickyfy.web.dto.response.MagazineResponse;
 import jakarta.persistence.EntityNotFoundException;
 import java.lang.reflect.Field;
@@ -17,6 +19,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -34,6 +38,9 @@ class MagazineServiceImplTest {
 
     @InjectMocks
     private MagazineServiceImpl magazineService;
+
+    @Captor
+    private ArgumentCaptor<Magazine> magazineArgumentCaptor;
 
     private Magazine magazine;
 
@@ -74,6 +81,27 @@ class MagazineServiceImplTest {
         // Then
         assertThat(magazineId).isEqualTo(1L);
         verify(magazineRepository).save(any(Magazine.class));
+    }
+
+    @Test
+    void updateMagazine_SuccessWithJustTitle() {
+        // Given
+        Magazine existingMagazine = new Magazine("기존 매거진", "test-icon.png");
+        MagazineUpdateRequest request = new MagazineUpdateRequest(
+                "수정된 매거진",
+                null
+        );
+
+        when(magazineRepository.findById(1L)).thenReturn(Optional.of(existingMagazine));
+
+        // When
+        magazineService.updateMagazine(1L, request);
+
+        // Then
+        verify(magazineRepository).findById(1L);
+
+        assertThat(existingMagazine.getTitle()).isEqualTo("수정된 매거진");
+        assertThat(existingMagazine.getIconUrl()).isEqualTo("test-icon.png");
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> #71

## 📝작업 내용

> 매거진 변경 요청 시 iconFile에 파일을 첨부하지 않고 요청하면 에러 발생
> 이는 의도하지 않은 에러 (title만 변경할 수 있도록 구현함)
> Service Layer에서 S3 저장소에 저장하는 로직을 null 값 검증
> 해당 테스트 코드 작성

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> Magazine의 update 메소드를 오버로딩을 구현하였는데 실제로 오버로딩으로 구현을 많이 하나요?

> MagazineSerivce의 updateMagazine 메소드에서 iconFile이 null일 경우 early return을 하는 방식으로 구현하였는데 이 또한 많이 사용된는 방식일까요?
