### PR TITLE
[Refactor] Placeupdate 시 PlaceImage update 로직 수정

### DIFF
--- a/src/main/java/com/pickyfy/pickyfy/domain/Place.java
+++ b/src/main/java/com/pickyfy/pickyfy/domain/Place.java
@@ -97,16 +97,11 @@ public class Place extends BaseTimeEntity {
     }
 
     public void updateImages(List<MultipartFile> newImages, S3Service s3Service) {
-        int currentSize = this.placeImages.size();
-        int availableSlots = 5 - currentSize;
 
-        if (availableSlots <= 0) {
-            return;
-        }
 
-        for (int i = 0; i < Math.min(newImages.size(), availableSlots); i++) {
+        for (int i = 0; i < newImages.size(); i++) {
             String imageUrl = s3Service.upload(newImages.get(i));
-            this.placeImages.add(PlaceImage.builder().place(this).url(imageUrl).sequence(currentSize + i).build());
+            this.placeImages.add(PlaceImage.builder().place(this).url(imageUrl).sequence(i).build());
         }
     }
 }

--- a/src/main/java/com/pickyfy/pickyfy/repository/PlaceImageRepository.java
+++ b/src/main/java/com/pickyfy/pickyfy/repository/PlaceImageRepository.java
@@ -1,5 +1,6 @@
 package com.pickyfy.pickyfy.repository;
 
+import com.pickyfy.pickyfy.domain.Place;
 import com.pickyfy.pickyfy.domain.PlaceImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,4 +11,6 @@ import java.util.List;
 public interface PlaceImageRepository extends JpaRepository<PlaceImage, Long> {
     @Query("SELECT pi.url FROM PlaceImage pi WHERE pi.place.id = :placeId")
     List<String> findAllByPlaceId(@Param("placeId") Long placeId);
+
+    List<PlaceImage> findALlByPlace(Place place);
 }

--- a/src/main/java/com/pickyfy/pickyfy/service/PlaceServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/PlaceServiceImpl.java
@@ -278,6 +278,9 @@ public class PlaceServiceImpl implements PlaceService {
         placeCategory.updatePlaceCategory(place, category);
         placeMagazine.updatePlaceMagazine(place, magazine);
 
+        List<PlaceImage> placeImages = placeImageRepository.findALlByPlace(place);
+        placeImageRepository.deleteAll(placeImages);
+
         if(imageList != null && !imageList.isEmpty()) {
             place.updateImages(imageList, s3Service);
         }


### PR DESCRIPTION
Placeupdate 시 PlaceImage update 로직 수정
> 프론트엔드에서 기존 PlaceImage 를 갖고 특정 place 조회나 전체 place 조회 등에 사용할 수 있다고, Place 수정 시 기존 PlaceImage 를 전체 삭제 하여 신규 이미지만 등록 하게끔 수정.