### PR TITLE
[Feat] 토큰 재발급 API , 권한 기반 접근 제한 구현

### DIFF
--- a/src/main/java/com/pickyfy/pickyfy/auth/filter/CustomLoginFilter.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/filter/CustomLoginFilter.java
@@ -63,7 +63,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 
         redisUtil.setDataExpire("refresh:" + jwtUtil.getPrincipal(refreshToken), refreshToken, Constant.REFRESH_TOKEN_EXPIRATION_TIME);
         response.setHeader("Authorization", "Bearer " + accessToken);
-        ResponseCookie cookie = createCookie("refreshToken", refreshToken, Constant.REFRESH_TOKEN_EXPIRATION_TIME);
+        ResponseCookie cookie = createCookie("refreshToken", refreshToken);
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
@@ -72,13 +72,13 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
         getFailureHandler().onAuthenticationFailure(request, response, exception);
     }
 
-    public ResponseCookie createCookie(String name, String value, long maxAge) {
+    public ResponseCookie createCookie(String name, String value) {
         return ResponseCookie.from(name, value)
-                .secure(true)
-                .sameSite("None")
                 .httpOnly(true)
+                .secure(false)
+                .sameSite("Lax")
                 .path("/")
-                .maxAge(Duration.ofMillis(maxAge).getSeconds())
+                .maxAge(Duration.ofMillis(Constant.REFRESH_TOKEN_EXPIRATION_TIME).getSeconds())
                 .build();
     }
 }

--- a/src/main/java/com/pickyfy/pickyfy/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/filter/JwtAuthFilter.java
@@ -27,7 +27,14 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
 
+        String requestURI = request.getRequestURI();
         String authorizationHeader = request.getHeader(ACCESS_TOKEN_HEADER);
+
+        if (requestURI.equals("/auth/reissue") && (authorizationHeader != null && authorizationHeader.startsWith(BEARER))) {
+            request.setAttribute("errorMessage", "Authorization이 포함되어있습니다.");
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+            }
 
         if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER)) {
             filterChain.doFilter(request, response);

--- a/src/main/java/com/pickyfy/pickyfy/auth/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,26 @@
+package com.pickyfy.pickyfy.auth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("""
+                {
+                    "isSuccess": false,
+                    "code": "403",
+                    "message": "해당 엔드포인트에 접근할 권한이 없습니다."
+                }
+                """);
+    }
+}

--- a/src/main/java/com/pickyfy/pickyfy/auth/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/handler/CustomAuthenticationEntryPoint.java
@@ -12,15 +12,20 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        String message = "인증 정보가 없습니다. 로그인 후 다시 시도하세요";
+
+        if(request.getAttribute("errorMessage") != null){
+            message = request.getAttribute("errorMessage").toString();
+        }
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.getWriter().write("""
+        response.getWriter().write(String.format("""
                 {
                     "isSuccess": false,
                     "code": "401",
-                    "message": "인증 정보가 없습니다. 로그인 후 다시 시도하세요."
+                    "message": "%s"
                 }
-                """);
+                """, message));
     }
 }

--- a/src/main/java/com/pickyfy/pickyfy/auth/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,26 @@
+package com.pickyfy.pickyfy.auth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("""
+                {
+                    "isSuccess": false,
+                    "code": "401",
+                    "message": "인증 정보가 없습니다. 로그인 후 다시 시도하세요."
+                }
+                """);
+    }
+}

--- a/src/main/java/com/pickyfy/pickyfy/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/handler/OAuth2SuccessHandler.java
@@ -36,26 +36,19 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         redisUtil.setDataExpire("refresh:" + email, refreshToken, Constant.REFRESH_TOKEN_EXPIRATION_TIME);
         response.setHeader("Authorization", "Bearer " + accessToken);
 
-        ResponseCookie cookie = createCookie("refreshToken", refreshToken, Constant.REFRESH_TOKEN_EXPIRATION_TIME);
+        ResponseCookie cookie = createCookie(refreshToken);
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-
-        String redirect = getRedirectUrl(request);
-        response.sendRedirect(redirect);
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
-    public String getRedirectUrl(HttpServletRequest request) {
-        return request.getSession().getAttribute("redirect").toString();
-    }
-
-    public ResponseCookie createCookie(String name, String value, long maxAge) {
-        return ResponseCookie.from(name, value)
-                .secure(true)
-                .sameSite("None")
+    private ResponseCookie createCookie(String refreshToken) {
+        return ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
+                .secure(false)
+                .sameSite("Lax")
                 .path("/")
-                .maxAge(Duration.ofMillis(maxAge).getSeconds())
+                .maxAge(Duration.ofMillis(Constant.REFRESH_TOKEN_EXPIRATION_TIME).getSeconds())
                 .build();
     }
 }

--- a/src/main/java/com/pickyfy/pickyfy/auth/oauth2/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/oauth2/CustomAuthorizationRequestResolver.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Component;
 public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
 
     private static final String AUTHORIZATION_REQUEST_BASE_URL = "/auth/oauth2";
-    private static final String QUERY_PARAM = "redirect";
 
     private final OAuth2AuthorizationRequestResolver defaultOAuth2AuthorizationRequestResolver;
 
@@ -22,26 +21,11 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
 
     @Override
     public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
-        OAuth2AuthorizationRequest authorizationRequest
-                = defaultOAuth2AuthorizationRequestResolver.resolve(request);
-        return setRedirect(request, authorizationRequest);
+        return defaultOAuth2AuthorizationRequestResolver.resolve(request);
     }
 
     @Override
     public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
-        OAuth2AuthorizationRequest authorizationRequest
-                = defaultOAuth2AuthorizationRequestResolver.resolve(request, clientRegistrationId);
-        return setRedirect(request, authorizationRequest);
-    }
-
-    private OAuth2AuthorizationRequest setRedirect(HttpServletRequest request, OAuth2AuthorizationRequest authorizationRequest){
-        if (authorizationRequest == null) {
-            return null;
-        }
-        String redirect = request.getParameter(QUERY_PARAM);
-        if (redirect != null) {
-            request.getSession().setAttribute(QUERY_PARAM, redirect);
-        }
-        return authorizationRequest;
+        return defaultOAuth2AuthorizationRequestResolver.resolve(request, clientRegistrationId);
     }
 }

--- a/src/main/java/com/pickyfy/pickyfy/common/config/SecurityConfig.java
+++ b/src/main/java/com/pickyfy/pickyfy/common/config/SecurityConfig.java
@@ -42,23 +42,6 @@ public class SecurityConfig {
     private final RedisUtil redisUtil;
 
     @Bean
-    public SecurityFilterChain oauthFilterChain(HttpSecurity http) throws Exception {
-
-        http
-                .securityMatcher("/auth/oauth2/**", "/oauth2/callback/**")
-                .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/auth/oauth2/**", "/oauth2/callback/**", "/**").permitAll())
-                .oauth2Login(oauth2 -> oauth2
-                        .authorizationEndpoint(endpoint -> endpoint
-                                .authorizationRequestResolver(customAuthorizationRequestResolver))
-                        .redirectionEndpoint(url -> url.baseUri("/oauth2/callback"))
-                        .userInfoEndpoint(endpoint -> endpoint.userService(oAuth2UserService))
-                        .successHandler(oAuth2SuccessHandler)
-                        .failureHandler(oAuth2FailureHandler));
-        return http.build();
-    }
-
-    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
@@ -70,7 +53,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/users/signup", "/auth/login", "/email-auth/**").permitAll()
+                        .requestMatchers("/users/signup", "/auth/login", "/email-auth/**", "/auth/reissue").permitAll()
                         .requestMatchers("/auth/oauth2/**", "/oauth2/callback").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/admin/**").hasAuthority("ADMIN")

--- a/src/main/java/com/pickyfy/pickyfy/common/config/SwaggerConfig.java
+++ b/src/main/java/com/pickyfy/pickyfy/common/config/SwaggerConfig.java
@@ -134,16 +134,11 @@ public class SwaggerConfig {
                     .summary("카카오 OAuth2 인증 요청")
                     .description("""
                     카카오 인증을 요청합니다.
-                    - 현재 서버에서 리다이렉션을 수행합니다.
                     - Swagger는 AJAX 요청을 사용하므로, 브라우저가 302 Redirect를
                       기본 페이지 이동으로 처리하지 않습니다.
                     - 테스트를 위해 브라우저에서 엔드포인트 URL을 직접 입력하여
                       카카오 로그인 화면으로 이동해야 합니다.
-
-                    추가적으로, ?redirect={URL} 쿼리 파라미터를 사용하여
-                    로그인 완료 후 리다이렉트할 최종 URL을 지정해야 합니다.
-                    - 예: /auth/oauth2/kakao?redirect=http://localhost:8080/home
-                    - 지정된 redirect URL로 최종 리다이렉션됩니다.
+                    - 로그인 성공 시 서버는 엑세스토큰을 Authorization 헤더에 리프레시토큰을 httpOnly 쿠키로 반환합니다.
                     """);
 
             PathItem authPathItem = new PathItem().get(authOperation);

--- a/src/main/java/com/pickyfy/pickyfy/common/util/JwtUtil.java
+++ b/src/main/java/com/pickyfy/pickyfy/common/util/JwtUtil.java
@@ -109,7 +109,4 @@ public class JwtUtil {
         return parseClaims(token).get(ROLE, String.class);
     }
 
-    public Long getExpirationDate(String token){
-        return parseClaims(token).getExpiration().getTime();
-    }
 }

--- a/src/main/java/com/pickyfy/pickyfy/common/util/JwtUtil.java
+++ b/src/main/java/com/pickyfy/pickyfy/common/util/JwtUtil.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.security.Key;
-import java.time.ZonedDateTime;
 import java.util.Date;
 
 @Slf4j
@@ -81,6 +80,7 @@ public class JwtUtil {
             log.info("잘못된 서명 혹은 JWT 형식 오류", e);
         } catch (ExpiredJwtException e) {
             log.info("토큰 만료", e);
+            throw new ExceptionHandler(ErrorStatus.TOKEN_EXPIRATION);
         } catch (UnsupportedJwtException e) {
             log.info("지원하지 않는 서명 알고리즘", e);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/pickyfy/pickyfy/service/AuthService.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/AuthService.java
@@ -1,5 +1,8 @@
 package com.pickyfy.pickyfy.service;
 
+import com.pickyfy.pickyfy.web.dto.response.AuthResponse;
+
 public interface AuthService {
     void logout(String refreshToken);
+    AuthResponse reIssue(String refreshToken);
 }

--- a/src/main/java/com/pickyfy/pickyfy/service/AuthServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/AuthServiceImpl.java
@@ -3,6 +3,9 @@ package com.pickyfy.pickyfy.service;
 import com.pickyfy.pickyfy.common.Constant;
 import com.pickyfy.pickyfy.common.util.JwtUtil;
 import com.pickyfy.pickyfy.common.util.RedisUtil;
+import com.pickyfy.pickyfy.exception.handler.ExceptionHandler;
+import com.pickyfy.pickyfy.web.apiResponse.error.ErrorStatus;
+import com.pickyfy.pickyfy.web.dto.response.AuthResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,5 +19,24 @@ public class AuthServiceImpl implements AuthService{
     @Override
     public void logout(String refreshToken){
         redisUtil.deleteRefreshToken(Constant.REDIS_KEY_PREFIX + jwtUtil.getPrincipal(refreshToken));
+    }
+
+    @Override
+    public AuthResponse reIssue(String token){
+        validateRefreshToken(token);
+        String principal = jwtUtil.getPrincipal(token);
+        String accessToken = jwtUtil.createAccessToken(principal, jwtUtil.getRole(token));
+        String refreshToken = jwtUtil.createRefreshToken(principal, jwtUtil.getRole(token));
+
+        redisUtil.setDataExpire("refresh:" + jwtUtil.getPrincipal(refreshToken), refreshToken, Constant.REFRESH_TOKEN_EXPIRATION_TIME);
+        return AuthResponse.from(accessToken, refreshToken);
+    }
+
+    public void validateRefreshToken(String token){
+        jwtUtil.validateToken(token);
+        String getToken = redisUtil.getData("refresh:" + jwtUtil.getPrincipal(token));
+        if(!token.equals(getToken)){
+            throw new ExceptionHandler(ErrorStatus.TOKEN_INVALID);
+        }
     }
 }

--- a/src/main/java/com/pickyfy/pickyfy/web/apiResponse/error/ErrorStatus.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/apiResponse/error/ErrorStatus.java
@@ -31,6 +31,7 @@ public enum ErrorStatus implements BaseErrorCode {
     KEY_NOT_FOUNT(HttpStatus.BAD_REQUEST, StatusCode.USER.getCode(4010), "존재하지 않는 키 값입니다."),
     AUTH_CODE_INVALID(HttpStatus.BAD_REQUEST, StatusCode.USER.getCode(4011), "잘못된 인증 코드입니다."),
     TOKEN_INVALID(HttpStatus.BAD_REQUEST, StatusCode.USER.getCode(4012), "유효하지 않은 토큰입니다."),
+    TOKEN_EXPIRATION(HttpStatus.BAD_REQUEST, StatusCode.USER.getCode(4013), "만료된 토큰입니다."),
 
     PLACE_NOT_FOUND(HttpStatus.BAD_REQUEST, StatusCode.USER.getCode(4001), "존재하지 않는 플레이스입니다."),
     ADD_PLACE_FAIL(HttpStatus.BAD_REQUEST, StatusCode.USER.getCode(4002), "[관리자] 플레이스 등록에 실패했습니다."),

--- a/src/main/java/com/pickyfy/pickyfy/web/controller/AuthController.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/controller/AuthController.java
@@ -1,7 +1,10 @@
 package com.pickyfy.pickyfy.web.controller;
 
+import com.pickyfy.pickyfy.common.Constant;
 import com.pickyfy.pickyfy.service.AuthService;
 import com.pickyfy.pickyfy.web.apiResponse.common.ApiResponse;
+import com.pickyfy.pickyfy.web.dto.response.AuthResponse;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -9,6 +12,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import java.time.Duration;
 
 @RestController
 @RequestMapping("/auth")
@@ -20,20 +24,48 @@ public class AuthController implements AuthControllerApi {
 
     @Override
     public ApiResponse<String> logout(
-            @CookieValue(value = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
+            @Parameter(hidden = true) @CookieValue(value = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
             HttpServletResponse response
     ) {
         if (refreshToken != null) {
             authService.logout(refreshToken);
         }
-        clearRefreshTokenCookie(response);
+        clearCookie(response);
         return ApiResponse.onSuccess("로그아웃에 성공했습니다.");
     }
 
-    private void clearRefreshTokenCookie(HttpServletResponse response) {
+    @Override
+    public ApiResponse<String> reIssue(
+            @Parameter(hidden = true) @CookieValue(value = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
+            HttpServletResponse response) {
+
+        if (refreshToken == null) {
+            return ApiResponse.onFailure("400","리프레시 토큰이 없습니다.", null);
+        }
+        AuthResponse authResponse = authService.reIssue(refreshToken);
+        response.setHeader("Authorization", "Bearer " + authResponse.accessToken());
+        createCookie(response, authResponse.refreshToken());
+
+        return ApiResponse.onSuccess("토큰 재발급 완료.");
+    }
+
+    private void createCookie(HttpServletResponse response, String refreshToken) {
+        ResponseCookie expiredCookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                .httpOnly(true)
+                .secure(false)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(Duration.ofMillis(Constant.REFRESH_TOKEN_EXPIRATION_TIME).getSeconds())
+                .build();
+
+        response.setHeader(HttpHeaders.SET_COOKIE, expiredCookie.toString());
+    }
+
+    private void clearCookie(HttpServletResponse response) {
         ResponseCookie expiredCookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
                 .httpOnly(true)
                 .secure(false)
+                .sameSite("Lax")
                 .path("/")
                 .maxAge(0)
                 .build();

--- a/src/main/java/com/pickyfy/pickyfy/web/controller/AuthControllerApi.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/controller/AuthControllerApi.java
@@ -3,19 +3,31 @@ package com.pickyfy.pickyfy.web.controller;
 import com.pickyfy.pickyfy.web.apiResponse.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 
+@Tag(name = "인증")
 public interface AuthControllerApi {
 
     @Operation(summary = "로그아웃 API", description = """
             - 로그아웃 API입니다.
-            - Cookie에 저장되어있는 refresh 토큰을 입력해주세요
+            - Swagger에서는 저장된 refresh 토큰이 자동으로 전송됩니다.
             - 완료 후 클라이언트측에서 Authorization header의 AccessToken을 제거해주세요.""")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
     })
     @PostMapping("/logout")
     ApiResponse<String> logout(@CookieValue(value = "refreshToken", required = false) String refreshToken, HttpServletResponse response);
+
+    @Operation(summary = "토큰 재발급 API", description = """
+        - 액세스 토큰을 재발급하는 API입니다.
+        - 요청 시 Authorization 헤더를 포함 x.
+        - Swagger에서는 저장된 refresh 토큰이 자동으로 전송됩니다.""")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
+    })
+    @PostMapping("/reissue")
+    ApiResponse<String> reIssue(@CookieValue(value = "refreshToken", required = false) String refreshToken, HttpServletResponse response);
 }

--- a/src/main/java/com/pickyfy/pickyfy/web/dto/response/AuthResponse.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/dto/response/AuthResponse.java
@@ -1,0 +1,11 @@
+package com.pickyfy.pickyfy.web.dto.response;
+
+public record AuthResponse(
+        String accessToken,
+        String refreshToken
+) {
+
+    public static AuthResponse from(String accessToken, String refreshToken){
+        return new AuthResponse(accessToken, refreshToken);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #66 

## 📝작업 내용

> 권한 기반 접근 제한을 구현하고 토큰 재발급 API 구현했습니다.
소셜로그인에서 기존 서버측 리다이렉트 방식에 문제가 있어 클라이언트측에서 리다이렉트를 처리하게 변경했습니다