### PR TITLE
[feat] 주변 플레이스 검색 response에 인스타, 네이버 링크 필드 추가

### DIFF
--- a/src/main/java/com/pickyfy/pickyfy/web/dto/response/NearbyPlaceResponse.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/dto/response/NearbyPlaceResponse.java
@@ -12,6 +12,8 @@ public record NearbyPlaceResponse(
         String shortDescription,
         BigDecimal latitude,
         BigDecimal longitude,
+        String instagramLink,
+        String naverLink,
         List<String> imageUrls,
         List<String> categories,
         List<String> magazines
@@ -42,6 +44,8 @@ public record NearbyPlaceResponse(
                 place.getShortDescription(),
                 place.getLatitude(),
                 place.getLongitude(),
+                place.getInstagramLink(),
+                place.getNaverplaceLink(),
                 images,
                 categoryNames,
                 magazineNames


### PR DESCRIPTION
## #️⃣연관된 이슈

> #92

## 📝작업 내용

> 주변 플레이스 검색에 제가 인스타, 네이버 링크를 빼먹어서 추가했습니다.

