### PR TITLE
[refactor] Api Response 수정

### DIFF
--- a/src/main/java/com/pickyfy/pickyfy/web/apiResponse/common/ApiResponse.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/apiResponse/common/ApiResponse.java
@@ -21,6 +21,10 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), result);
     }
 
+    public static <T> ApiResponse<T> onSuccess(SuccessStatus status, T result) {
+        return new ApiResponse<>(true, status.getCode(), status.getMessage(), result);
+    }
+
     public static <T> ApiResponse<T> onFailure(String code, String message, T data){
         return new ApiResponse<>(false, code, message, data);
     }

--- a/src/main/java/com/pickyfy/pickyfy/web/apiResponse/common/StatusCode.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/apiResponse/common/StatusCode.java
@@ -8,7 +8,8 @@ public enum StatusCode {
     MAGAZINE("MAGAZINE"),
     ADMIN("ADMIN"),
     CATEGORY("CATEGORY"),
-    IMAGE("IMAGE");
+    IMAGE("IMAGE"),
+    EMAIL("EMAIL");
 
     private final String prefix;
 

--- a/src/main/java/com/pickyfy/pickyfy/web/apiResponse/success/SuccessStatus.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/apiResponse/success/SuccessStatus.java
@@ -18,6 +18,7 @@ public enum SuccessStatus implements BaseSuccessCode {
     LOGOUT_SUCCESS(HttpStatus.OK, StatusCode.USER.getCode(2001), "성공적으로 로그아웃되었습니다."),
     USER_EDIT_SUCCESS(HttpStatus.OK, StatusCode.USER.getCode(2002), "유저 정보가 성공적으로 변경되었습니다."),
     USER_SING_OUT_SUCCESS(HttpStatus.OK, StatusCode.USER.getCode(2003), "성공적으로 탈퇴되었습니다."),
+    REISSUE_TOKEN_SUCCESS(HttpStatus.OK, StatusCode.USER.getCode(2003), "토큰이 성공적으로 재발급되었습니다."),
 
     ADMIN_LOGIN_SUCCESS(HttpStatus.OK, StatusCode.ADMIN.getCode(2011), "[관리자] 성공적으로 로그인되었습니다."),
     ADMIN_LOGOUT_SUCCESS(HttpStatus.OK, StatusCode.ADMIN.getCode(2012), "[관리자] 성공적으로 로그아웃되었습니다."),

--- a/src/main/java/com/pickyfy/pickyfy/web/apiResponse/success/SuccessStatus.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/apiResponse/success/SuccessStatus.java
@@ -19,6 +19,7 @@ public enum SuccessStatus implements BaseSuccessCode {
     USER_EDIT_SUCCESS(HttpStatus.OK, StatusCode.USER.getCode(2002), "유저 정보가 성공적으로 변경되었습니다."),
     USER_SING_OUT_SUCCESS(HttpStatus.OK, StatusCode.USER.getCode(2003), "성공적으로 탈퇴되었습니다."),
     REISSUE_TOKEN_SUCCESS(HttpStatus.OK, StatusCode.USER.getCode(2003), "토큰이 성공적으로 재발급되었습니다."),
+    USER_INFO_RETRIEVED(HttpStatus.OK, StatusCode.USER.getCode(2004), "유저 정보가 조회되었습니다."),
 
     ADMIN_LOGIN_SUCCESS(HttpStatus.OK, StatusCode.ADMIN.getCode(2011), "[관리자] 성공적으로 로그인되었습니다."),
     ADMIN_LOGOUT_SUCCESS(HttpStatus.OK, StatusCode.ADMIN.getCode(2012), "[관리자] 성공적으로 로그아웃되었습니다."),
@@ -28,14 +29,21 @@ public enum SuccessStatus implements BaseSuccessCode {
     ADD_PLACE_SUCCESS(HttpStatus.OK, StatusCode.PLACE.getCode(2011), "[관리자] 플레이스가 성공적으로 등록되었습니다."),
     EDIT_PLACE_SUCCESS(HttpStatus.OK, StatusCode.PLACE.getCode(2002), "[관리자] 플레이스가 성공적으로 수정되었습니다."),
     DELETE_PLACE_SUCCESS(HttpStatus.OK, StatusCode.PLACE.getCode(2003), "[관리자] 플레이스가 성공적으로 삭제되었습니다."),
+    PLACES_RETRIEVED(HttpStatus.OK, StatusCode.MAGAZINE.getCode(2004), "플레이스 목록이 조회되었습니다."),
+    NEARBY_PLACES_RETRIEVED(HttpStatus.OK, StatusCode.MAGAZINE.getCode(2005), "주변 플레이스 목록이 조회되었습니다."),
 
     ADD_MAGAZINE_SUCCESS(HttpStatus.OK, StatusCode.MAGAZINE.getCode(2011), "[관리자] 매거진이 성공적으로 등록되었습니다."),
     EDIT_MAGAZINE_SUCCESS(HttpStatus.OK, StatusCode.MAGAZINE.getCode(2001), "[관리자] 매거진이 성공적으로 수정되었습니다."),
     DELETE_MAGAZINE_SUCCESS(HttpStatus.OK, StatusCode.MAGAZINE.getCode(2002), "[관리자] 플레이스가 성공적으로 삭제되었습니다."),
+    MAGAZINES_RETRIEVED(HttpStatus.OK, StatusCode.MAGAZINE.getCode(2003), "매거진 목록이 조회되었습니다."),
 
     ADD_CATEGORY_SUCCESS(HttpStatus.OK, StatusCode.CATEGORY.getCode(2011), "[관리자] 카테고리가 성공적으로 등록되었습니다."),
     EDIT_CATEGORY_SUCCESS(HttpStatus.OK, StatusCode.CATEGORY.getCode(2001), "[관리자] 카테고리가 성공적으로 수정되었습니다."),
-    DELETE_CATEGORY_SUCCESS(HttpStatus.OK, StatusCode.CATEGORY.getCode(2002), "[관리자] 카테고리가 성공적으로 삭제되었습니다.");
+    DELETE_CATEGORY_SUCCESS(HttpStatus.OK, StatusCode.CATEGORY.getCode(2002), "[관리자] 카테고리가 성공적으로 삭제되었습니다."),
+    CATEGORIES_RETRIEVED(HttpStatus.OK, StatusCode.CATEGORY.getCode(2003), "카테고리 목록이 조회되었습니다."),
+
+    EMAIL_SENT(HttpStatus.OK, StatusCode.EMAIL.getCode(2003), "이메일이 발송되었습니다."),
+    EMAIL_VERIFIED(HttpStatus.OK, StatusCode.EMAIL.getCode(2004), "이메일이 인증되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/pickyfy/pickyfy/web/controller/AuthController.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.pickyfy.pickyfy.web.controller;
 import com.pickyfy.pickyfy.common.Constant;
 import com.pickyfy.pickyfy.service.AuthService;
 import com.pickyfy.pickyfy.web.apiResponse.common.ApiResponse;
+import com.pickyfy.pickyfy.web.apiResponse.success.SuccessStatus;
 import com.pickyfy.pickyfy.web.dto.response.AuthResponse;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletResponse;
@@ -23,7 +24,7 @@ public class AuthController implements AuthControllerApi {
     private final AuthService authService;
 
     @Override
-    public ApiResponse<String> logout(
+    public ApiResponse<Void> logout(
             @Parameter(hidden = true) @CookieValue(value = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
             HttpServletResponse response
     ) {
@@ -31,11 +32,11 @@ public class AuthController implements AuthControllerApi {
             authService.logout(refreshToken);
         }
         clearCookie(response);
-        return ApiResponse.onSuccess("로그아웃에 성공했습니다.");
+        return ApiResponse.onSuccess(SuccessStatus.LOGOUT_SUCCESS, null);
     }
 
     @Override
-    public ApiResponse<String> reIssue(
+    public ApiResponse<Void> reIssue(
             @Parameter(hidden = true) @CookieValue(value = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
             HttpServletResponse response) {
 
@@ -46,7 +47,7 @@ public class AuthController implements AuthControllerApi {
         response.setHeader("Authorization", "Bearer " + authResponse.accessToken());
         createCookie(response, authResponse.refreshToken());
 
-        return ApiResponse.onSuccess("토큰 재발급 완료.");
+        return ApiResponse.onSuccess(SuccessStatus.REISSUE_TOKEN_SUCCESS, null);
     }
 
     private void createCookie(HttpServletResponse response, String refreshToken) {

--- a/src/main/java/com/pickyfy/pickyfy/web/controller/AuthControllerApi.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/controller/AuthControllerApi.java
@@ -19,7 +19,7 @@ public interface AuthControllerApi {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
     })
     @PostMapping("/logout")
-    ApiResponse<String> logout(@CookieValue(value = "refreshToken", required = false) String refreshToken, HttpServletResponse response);
+    ApiResponse<Void> logout(@CookieValue(value = "refreshToken", required = false) String refreshToken, HttpServletResponse response);
 
     @Operation(summary = "토큰 재발급 API", description = """
         - 액세스 토큰을 재발급하는 API입니다.
@@ -29,5 +29,5 @@ public interface AuthControllerApi {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
     })
     @PostMapping("/reissue")
-    ApiResponse<String> reIssue(@CookieValue(value = "refreshToken", required = false) String refreshToken, HttpServletResponse response);
+    ApiResponse<Void> reIssue(@CookieValue(value = "refreshToken", required = false) String refreshToken, HttpServletResponse response);
 }

--- a/src/main/java/com/pickyfy/pickyfy/web/controller/CategoryController.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/controller/CategoryController.java
@@ -2,6 +2,7 @@ package com.pickyfy.pickyfy.web.controller;
 
 import com.pickyfy.pickyfy.web.apiResponse.common.ApiResponse;
 import com.pickyfy.pickyfy.service.CategoryService;
+import com.pickyfy.pickyfy.web.apiResponse.success.SuccessStatus;
 import com.pickyfy.pickyfy.web.dto.request.CategoryCreateRequest;
 import com.pickyfy.pickyfy.web.dto.request.CategoryUpdateRequest;
 import com.pickyfy.pickyfy.web.dto.response.CategoryResponse;
@@ -26,19 +27,19 @@ public class CategoryController implements CategoryControllerApi{
     @PostMapping("/admin/category")
     public ApiResponse<Long> createCategory(@Valid @RequestBody CategoryCreateRequest request) {
         Long categoryId = categoryService.createCategory(request);
-        return ApiResponse.onSuccess(categoryId);
+        return ApiResponse.onSuccess(SuccessStatus.ADD_CATEGORY_SUCCESS, categoryId);
     }
 
     @GetMapping("/category/{id}")
     public ApiResponse<CategoryResponse> getCategory(@PathVariable Long id) {
         CategoryResponse response = categoryService.getCategory(id);
-        return ApiResponse.onSuccess(response);
+        return ApiResponse.onSuccess(SuccessStatus.CATEGORIES_RETRIEVED, response);
     }
 
     @GetMapping("/categories")
     public ApiResponse<List<CategoryResponse>> getAllCategories() {
         List<CategoryResponse> responses = categoryService.getAllCategories();
-        return ApiResponse.onSuccess(responses);
+        return ApiResponse.onSuccess(SuccessStatus.CATEGORIES_RETRIEVED, responses);
     }
 
     @PutMapping("/admin/category/{id}")
@@ -46,12 +47,12 @@ public class CategoryController implements CategoryControllerApi{
             @PathVariable Long id,
             @Valid @RequestBody CategoryUpdateRequest request) {
         categoryService.updateCategory(id, request);
-        return ApiResponse.onSuccess(id);
+        return ApiResponse.onSuccess(SuccessStatus.EDIT_CATEGORY_SUCCESS, id);
     }
 
     @DeleteMapping("/admin/category/{id}")
     public ApiResponse<Long> deleteCategory(@PathVariable Long id) {
         categoryService.deleteCategory(id);
-        return ApiResponse.onSuccess(id);
+        return ApiResponse.onSuccess(SuccessStatus.DELETE_CATEGORY_SUCCESS, id);
     }
 }

--- a/src/main/java/com/pickyfy/pickyfy/web/controller/EmailController.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/controller/EmailController.java
@@ -1,6 +1,7 @@
 package com.pickyfy.pickyfy.web.controller;
 
 import com.pickyfy.pickyfy.web.apiResponse.common.ApiResponse;
+import com.pickyfy.pickyfy.web.apiResponse.success.SuccessStatus;
 import com.pickyfy.pickyfy.web.dto.request.EmailVerificationSendRequest;
 import com.pickyfy.pickyfy.web.dto.request.EmailVerificationVerifyRequest;
 import com.pickyfy.pickyfy.web.dto.response.EmailVerificationSendResponse;
@@ -24,7 +25,7 @@ public class EmailController implements EmailControllerApi {
             @Valid @RequestBody EmailVerificationSendRequest emailVerificationSendRequest
     ){
         EmailVerificationSendResponse emailVerificationSendResponse = emailService.sendAuthCode(emailVerificationSendRequest);
-        return ApiResponse.onSuccess(emailVerificationSendResponse);
+        return ApiResponse.onSuccess(SuccessStatus.EMAIL_SENT, emailVerificationSendResponse);
     }
 
     @Override
@@ -32,6 +33,6 @@ public class EmailController implements EmailControllerApi {
             @Valid @RequestBody EmailVerificationVerifyRequest emailVerificationVerifyRequest
     ){
         EmailVerificationVerifyResponse emailVerificationVerifyResponse = emailService.verifyAuthCode(emailVerificationVerifyRequest);
-        return ApiResponse.onSuccess(emailVerificationVerifyResponse);
+        return ApiResponse.onSuccess(SuccessStatus.EMAIL_VERIFIED, emailVerificationVerifyResponse);
     }
 }

--- a/src/main/java/com/pickyfy/pickyfy/web/controller/MagazineController.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/controller/MagazineController.java
@@ -2,6 +2,7 @@ package com.pickyfy.pickyfy.web.controller;
 
 import com.pickyfy.pickyfy.web.apiResponse.common.ApiResponse;
 import com.pickyfy.pickyfy.service.MagazineService;
+import com.pickyfy.pickyfy.web.apiResponse.success.SuccessStatus;
 import com.pickyfy.pickyfy.web.dto.request.MagazineCreateRequest;
 import com.pickyfy.pickyfy.web.dto.request.MagazineUpdateRequest;
 import com.pickyfy.pickyfy.web.dto.response.MagazineResponse;
@@ -28,19 +29,19 @@ public class MagazineController implements MagazineControllerApi {
     @PostMapping(value = "/admin/magazines", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<Long> createMagazine(@Valid @ModelAttribute MagazineCreateRequest request) {
         Long magazineId = magazineService.createMagazine(request);
-        return ApiResponse.onSuccess(magazineId);
+        return ApiResponse.onSuccess(SuccessStatus.ADD_MAGAZINE_SUCCESS, magazineId);
     }
 
     @GetMapping("/magazines/{id}")
     public ApiResponse<MagazineResponse> getMagazine(@PathVariable Long id) {
         MagazineResponse response = magazineService.getMagazine(id);
-        return ApiResponse.onSuccess(response);
+        return ApiResponse.onSuccess(SuccessStatus.MAGAZINES_RETRIEVED, response);
     }
 
     @GetMapping("/magazines")
     public ApiResponse<List<MagazineResponse>> getAllMagazines() {
         List<MagazineResponse> responses = magazineService.getAllMagazines();
-        return ApiResponse.onSuccess(responses);
+        return ApiResponse.onSuccess(SuccessStatus.MAGAZINES_RETRIEVED, responses);
     }
 
     @PutMapping(value = "/admin/magazines/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -48,12 +49,12 @@ public class MagazineController implements MagazineControllerApi {
             @PathVariable Long id,
             @Valid @ModelAttribute MagazineUpdateRequest request) {
         magazineService.updateMagazine(id, request);
-        return ApiResponse.onSuccess(id);
+        return ApiResponse.onSuccess(SuccessStatus.EDIT_MAGAZINE_SUCCESS, id);
     }
 
     @DeleteMapping("/admin/magazines/{id}")
     public ApiResponse<Long> deleteMagazine(@PathVariable Long id) {
         magazineService.deleteMagazine(id);
-        return ApiResponse.onSuccess(id);
+        return ApiResponse.onSuccess(SuccessStatus.DELETE_MAGAZINE_SUCCESS, id);
     }
 }

--- a/src/main/java/com/pickyfy/pickyfy/web/controller/PlaceController.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/controller/PlaceController.java
@@ -5,12 +5,12 @@ import com.pickyfy.pickyfy.exception.handler.ExceptionHandler;
 import com.pickyfy.pickyfy.service.PlaceService;
 import com.pickyfy.pickyfy.web.apiResponse.common.ApiResponse;
 import com.pickyfy.pickyfy.web.apiResponse.error.ErrorStatus;
+import com.pickyfy.pickyfy.web.apiResponse.success.SuccessStatus;
 import com.pickyfy.pickyfy.web.dto.request.NearbyPlaceSearchRequest;
 import com.pickyfy.pickyfy.web.dto.request.PlaceCreateRequest;
 import com.pickyfy.pickyfy.web.dto.response.NearbyPlaceResponse;
 import com.pickyfy.pickyfy.web.dto.response.PlaceSearchResponse;
 import com.pickyfy.pickyfy.service.PlaceServiceImpl;
-import com.pickyfy.pickyfy.web.dto.response.UserInfoResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -36,7 +36,7 @@ public class PlaceController implements PlaceControllerApi {
         String email = getUserEmail();
         List<PlaceSearchResponse> allPlace = placeService.getUserSavePlace(email);
 
-        return ApiResponse.onSuccess(allPlace);
+        return ApiResponse.onSuccess(SuccessStatus.PLACES_RETRIEVED, allPlace);
     }
 
     /**
@@ -45,22 +45,23 @@ public class PlaceController implements PlaceControllerApi {
     @GetMapping("/{placeId}")
     public ApiResponse<PlaceSearchResponse> getPlace(@PathVariable Long placeId) {
         PlaceSearchResponse response = placeService.getPlace(placeId);
-        return ApiResponse.onSuccess(response);
+        return ApiResponse.onSuccess(SuccessStatus.PLACES_RETRIEVED, response);
     }
 
     /**
      * 플레이스 저장/삭제 토글
      */
     @PatchMapping("/toggle")
-    public ApiResponse<String> togglePlaceUser(@RequestParam Long placeId) {
+    public ApiResponse<Void> togglePlaceUser(@RequestParam Long placeId) {
         String email = getUserEmail();
         boolean isSaved = placeService.togglePlaceUser(email,placeId);
-        return ApiResponse.onSuccess(isSaved ? "Place saved successfully." : "Place removed successfully.");
+        return ApiResponse.onSuccess(isSaved ? SuccessStatus.SAVE_PLACE_SUCCESS : SuccessStatus.DELETE_PLACE_SUCCESS, null);
     }
 
     @PostMapping("/nearby")
     public ApiResponse<List<NearbyPlaceResponse>> searchNearbyPlaces(@RequestBody NearbyPlaceSearchRequest request) {
         return ApiResponse.onSuccess(
+                SuccessStatus.NEARBY_PLACES_RETRIEVED,
                 placeService.searchNearbyPlaces(
                         request.latitude(),
                         request.longitude(),
@@ -72,12 +73,6 @@ public class PlaceController implements PlaceControllerApi {
                 .toList()
         );
     }
-
-    /**
-     * 관리자 페이지에서 모든 Place 조회
-     * @param
-     * @return
-     */
 
     private String getUserEmail(){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -104,7 +99,7 @@ class AdminPlaceController implements AdminControllerAPi{
             @RequestPart(value = "image", required = false) List<MultipartFile> images,
             @RequestPart PlaceCreateRequest request) {
         Long id = placeService.createPlace(request, images);
-        return ApiResponse.onSuccess(id);
+        return ApiResponse.onSuccess(SuccessStatus.ADD_PLACE_SUCCESS, id);
     }
 
     /**
@@ -116,7 +111,7 @@ class AdminPlaceController implements AdminControllerAPi{
             @RequestPart("request") @Valid PlaceCreateRequest request,
             @RequestPart(value = "image", required = false) List<MultipartFile> images) {
         Long id = placeService.updatePlace(placeId, request, images);
-        return ApiResponse.onSuccess(id);
+        return ApiResponse.onSuccess(SuccessStatus.EDIT_PLACE_SUCCESS, id);
     }
 
     /**
@@ -125,16 +120,7 @@ class AdminPlaceController implements AdminControllerAPi{
     @DeleteMapping("/{placeId}")
     public ApiResponse<Void> deletePlace(@PathVariable Long placeId) {
         placeService.deletePlace(placeId);
-        return ApiResponse.onSuccess(null);
-    }
-
-    /**
-     * 특정 플레이스의 이미지 삭제 (관리자)
-     */
-    @DeleteMapping("/images/{placeImageId}")
-    public ApiResponse<Void> deletePlaceImages(@PathVariable Long placeId, @PathVariable Long placeImageId) {
-        placeService.deletePlaceImages(placeImageId);
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.onSuccess(SuccessStatus.DELETE_PLACE_SUCCESS, null);
     }
 
     /**
@@ -143,7 +129,7 @@ class AdminPlaceController implements AdminControllerAPi{
     @GetMapping
     public ApiResponse<List<PlaceSearchResponse>> getAllPlace() {
         List<PlaceSearchResponse> adminAllPlace = placeService.getAdminAllPlace();
-        return ApiResponse.onSuccess(adminAllPlace);
+        return ApiResponse.onSuccess(SuccessStatus.PLACES_RETRIEVED, adminAllPlace);
     }
 }
 

--- a/src/main/java/com/pickyfy/pickyfy/web/controller/PlaceControllerApi.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/controller/PlaceControllerApi.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -39,7 +38,7 @@ public interface PlaceControllerApi {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
     })
     @PatchMapping("/toggle")
-    ApiResponse<String> togglePlaceUser(@RequestParam Long placeId);
+    ApiResponse<Void> togglePlaceUser(@RequestParam Long placeId);
 
     @Operation(
             summary = "주변 장소 검색 API",
@@ -100,15 +99,6 @@ interface AdminControllerAPi{
     })
     @DeleteMapping("/admin/places/{placeId}")
     ApiResponse<Void> deletePlace(@PathVariable Long placeId);
-
-    @Operation(summary = "PlaceImage 삭제", description = "PlaceImage 선택 삭제 합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
-    })
-    @DeleteMapping("/admin/places/images/{placeImageId}")
-    ApiResponse<Void> deletePlaceImages(@PathVariable Long placeId, @PathVariable Long placeImageId);
-
-
 
     @Operation(summary = "모든 Place 조회", description = "모든 Place를 조회 합니다.")
     @ApiResponses({

--- a/src/main/java/com/pickyfy/pickyfy/web/controller/UserController.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/controller/UserController.java
@@ -1,11 +1,11 @@
 package com.pickyfy.pickyfy.web.controller;
 
 import com.pickyfy.pickyfy.auth.details.CustomUserDetails;
-import com.pickyfy.pickyfy.common.util.TokenExtractor;
 import com.pickyfy.pickyfy.exception.handler.ExceptionHandler;
 import com.pickyfy.pickyfy.web.apiResponse.common.ApiResponse;
 import com.pickyfy.pickyfy.service.UserService;
 import com.pickyfy.pickyfy.web.apiResponse.error.ErrorStatus;
+import com.pickyfy.pickyfy.web.apiResponse.success.SuccessStatus;
 import com.pickyfy.pickyfy.web.dto.request.EmailVerificationSendRequest;
 import com.pickyfy.pickyfy.web.dto.request.PasswordResetRequest;
 import com.pickyfy.pickyfy.web.dto.request.UserCreateRequest;
@@ -28,31 +28,31 @@ public class UserController implements UserControllerApi{
 
     public ApiResponse<UserCreateResponse> signUp(@Valid UserCreateRequest request) {
         UserCreateResponse response = userService.signUp(request);
-        return ApiResponse.onSuccess(response);
+        return ApiResponse.onSuccess(SuccessStatus.SIGN_IN_SUCCESS, response);
     }
 
     @GetMapping("/getInfo")
     public ApiResponse<UserInfoResponse> getUserInfo(){
         UserInfoResponse response = userService.getUser(getUserEmail());
-        return ApiResponse.onSuccess(response);
+        return ApiResponse.onSuccess(SuccessStatus.USER_INFO_RETRIEVED, response);
     }
 
     @PatchMapping(value = "/update", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<Long> updateUser(@Valid @ModelAttribute UserUpdateRequest request) {
         Long userId = userService.updateUser(getUserEmail(), request);
-        return ApiResponse.onSuccess(userId);
+        return ApiResponse.onSuccess(SuccessStatus.USER_EDIT_SUCCESS, userId);
     }
 
     @DeleteMapping("/signOut")
-    public ApiResponse<String> signOut(){
+    public ApiResponse<Void> signOut(){
         userService.signOut(getUserEmail());
-        return ApiResponse.onSuccess("회원 탈퇴에 성공했습니다.");
+        return ApiResponse.onSuccess(SuccessStatus.USER_SING_OUT_SUCCESS,null);
     }
 
     @PostMapping("/verify-by-email")
-    public ApiResponse<String> verifyByEmail(@Valid @RequestBody EmailVerificationSendRequest request){
+    public ApiResponse<Void> verifyByEmail(@Valid @RequestBody EmailVerificationSendRequest request){
         userService.verifyByEmail(request.email());
-        return ApiResponse.onSuccess("존재하는 유저 정보입니다.");
+        return ApiResponse.onSuccess(SuccessStatus.EMAIL_VERIFIED,null);
     }
 
     @PatchMapping("/reset-password")

--- a/src/main/java/com/pickyfy/pickyfy/web/controller/UserControllerApi.java
+++ b/src/main/java/com/pickyfy/pickyfy/web/controller/UserControllerApi.java
@@ -43,7 +43,7 @@ public interface UserControllerApi {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
     })
     @DeleteMapping("/signOut")
-    ApiResponse<String> signOut();
+    ApiResponse<Void> signOut();
 
     @Operation(summary = "비밀번호 재설정 시 유저검증 API", description =
             """
@@ -64,7 +64,7 @@ public interface UserControllerApi {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
     })
     @PostMapping("/verify-by-email")
-    ApiResponse<String> verifyByEmail(@Valid @RequestBody EmailVerificationSendRequest request);
+    ApiResponse<Void> verifyByEmail(@Valid @RequestBody EmailVerificationSendRequest request);
 
     @Operation(summary = "비밀번호 재설정 API", description = "- 이메일, 새로운 비밀번호, 이메일 토큰을 입력해주세요.\n- 비밀번호는 8자 이상의 영문, 숫자, 특수문자를 조합하여 입력해주세요.")
     @ApiResponses({

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local, dev #로컬 + ec2 내부 dev 환경
+    active: local
   sql:
     init:
       mode: never


### PR DESCRIPTION
## #️⃣연관된 이슈

> #95

## 📝작업 내용

> 기존 Api response는 OK를 하드코딩 해 놓아서 SuccessStatus를 이용할 수 없었습니다.
> 따라서 파라미터로 Status를 받도록 수정


## 💬리뷰 요구사항(선택)

> 궁금한 점이 SuccessStatus의 코드들(2001, 2002 등)은 어떤 기준으로 작성된 건가요? 어떤 건 2011부터 시작하길래 궁금합니다.
