### PR TITLE
[feat] PlaceService 테스트 코드 작성 및 저장된 플레이스 조회 null값 검증 추가

### DIFF
--- a/src/main/java/com/pickyfy/pickyfy/service/PlaceServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/PlaceServiceImpl.java
@@ -11,6 +11,7 @@ import com.pickyfy.pickyfy.web.dto.response.UserInfoResponse;
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigDecimal;
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,13 +48,19 @@ public class PlaceServiceImpl implements PlaceService {
         User user = userRepository.findByEmail(email).orElseThrow(() -> new EntityNotFoundException(ErrorStatus.USER_NOT_FOUND.getMessage()));
         List<SavedPlace> allPlaceList = savedPlaceRepository.findAllByUserId(user.getId());
 
+        if (allPlaceList.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         return allPlaceList.stream()
                 .map(savedPlace -> {
 
                     List<PlaceSavedPlace> placeSavedPlaces = placeSavedPlaceRepository.findAllBySavedPlaceId(savedPlace.getId());
                     Long savedPlaceId = savedPlace.getId();
                     PlaceSavedPlace mappingPlace = placeSavedPlaceRepository.findBySavedPlaceId(savedPlaceId);
-
+                    if (mappingPlace == null || mappingPlace.getPlace() == null) {
+                        return null;
+                    }
 
                     Place userSavePlace = placeRepository.findById(mappingPlace.getPlace().getId()).orElseThrow(() -> new EntityNotFoundException("Place not found"));
 

--- a/src/test/java/com/pickyfy/pickyfy/service/PlaceServiceImplTest.java
+++ b/src/test/java/com/pickyfy/pickyfy/service/PlaceServiceImplTest.java
@@ -30,9 +30,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-//@SpringBootTest
-//@Transactional
-class PlaceServiceImplTest {/*
+@SpringBootTest
+@Transactional
+class PlaceServiceImplTest {
 
     @Autowired
     private PlaceService placeService;
@@ -133,7 +133,7 @@ class PlaceServiceImplTest {/*
         placeRepository.save(place);
 
         // When
-        List<PlaceSearchResponse> result = placeService.getUserSavePlace(user.getId());
+        List<PlaceSearchResponse> result = placeService.getUserSavePlace(user.getEmail());
 
         // Then
         assertThat(result).hasSize(1);
@@ -164,12 +164,10 @@ class PlaceServiceImplTest {/*
         userRepository.save(user);
 
         // When
-        List<PlaceSearchResponse> result = placeService.getUserSavePlace(user.getId());
+        List<PlaceSearchResponse> result = placeService.getUserSavePlace(user.getEmail());
 
         // Then
         assertThat(result).isEmpty();
     }
-
- */
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #99

## 📝작업 내용

> PlaceService에 존재하는 메소드 테스트 코드 작성

> 저장된 플레이스 조회 시 유저가 저장한 플레이스가 없으면 null을 반환하도록 구현

![스크린샷 2025-02-12 164743](https://github.com/user-attachments/assets/02537674-011f-4770-be62-fa2dae65e406)

## 💬리뷰 요구사항(선택)

#### 1. [e698e6a](https://github.com/Team-Pickify/backend/pull/102/commits/e698e6a291ca107064026a09fde49396afc6e8d7) 이 부분 null값 검증 방식 봐주세요

#### 2. 테스트 DB가 격리되지 않았습니다
> 실제 DB에서 테스트 중
> Spring Boot의 기본 내장 H2 메모리 DB로 테스트를 옮기려 했으나 자잘한 문제로 실패했습니다. (H2는 user라는 이름의 테이블 생성 불가.. 등)

>따라서 전체 플레이스 조회 메소드는 매번 데이터가 변경될 것이므로 테스트코드를 작성하지 않았습니다.
> 주변 플레이스 조회는 매우 특수한 위경도로 설정하여 실제 데이터와 구분했습니다.

