### PR TITLE
[Feat] Redis 캐싱 적용

### DIFF
--- a/src/main/java/com/pickyfy/pickyfy/auth/filter/CustomLoginFilter.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/filter/CustomLoginFilter.java
@@ -59,7 +59,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String accessToken = jwtUtil.createAccessToken(principal, role);
         String refreshToken = jwtUtil.createRefreshToken(principal, role);
-        redisUtil.setDataExpire("refresh:" + jwtUtil.getPrincipal(refreshToken), refreshToken, Constant.REFRESH_TOKEN_EXPIRATION_TIME);
+        redisUtil.setData("refresh:" + jwtUtil.getPrincipal(refreshToken), refreshToken, Constant.REFRESH_TOKEN_EXPIRATION_TIME);
 
         setBody(role, response);
         ResponseCookie accessCookie = createCookie("accessToken", accessToken, Constant.ACCESS_TOKEN_EXPIRATION_TIME, "/");

--- a/src/main/java/com/pickyfy/pickyfy/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/pickyfy/pickyfy/auth/handler/OAuth2SuccessHandler.java
@@ -35,7 +35,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String accessToken = jwtUtil.createAccessToken(email, "USER");
         String refreshToken = jwtUtil.createRefreshToken(email, "USER");
 
-        redisUtil.setDataExpire("refresh:" + email, refreshToken, Constant.REFRESH_TOKEN_EXPIRATION_TIME);
+        redisUtil.setData("refresh:" + email, refreshToken, Constant.REFRESH_TOKEN_EXPIRATION_TIME);
 
         ResponseCookie accessCookie = createCookie("accessToken", accessToken, Constant.ACCESS_TOKEN_EXPIRATION_TIME, "/");
         response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());

--- a/src/main/java/com/pickyfy/pickyfy/common/Constant.java
+++ b/src/main/java/com/pickyfy/pickyfy/common/Constant.java
@@ -9,5 +9,9 @@ public class Constant {
     public static final long ACCESS_TOKEN_EXPIRATION_TIME = 30 * 60 * 1000;
     public static final long REFRESH_TOKEN_EXPIRATION_TIME = 7 * 24 * 60 * 60 * 1000;
 
+    public static final long CATEGORIES_EXPIRATION_TIME = 24 * 60 * 60 * 1000;
+    public static final long MAGAZINES_EXPIRATION_TIME = 60 * 60 * 1000;
+    public static final long PLACES_EXPIRATION_TIME = 30 * 60 * 1000;
+
     public static final String REDIS_KEY_PREFIX = "refresh:";
 }

--- a/src/main/java/com/pickyfy/pickyfy/common/Constant.java
+++ b/src/main/java/com/pickyfy/pickyfy/common/Constant.java
@@ -12,6 +12,7 @@ public class Constant {
     public static final long CATEGORIES_EXPIRATION_TIME = 24 * 60 * 60 * 1000;
     public static final long MAGAZINES_EXPIRATION_TIME = 60 * 60 * 1000;
     public static final long PLACES_EXPIRATION_TIME = 30 * 60 * 1000;
+    public static final long PLACE_EXPIRATION_TIME = 30 * 60 * 1000;
 
     public static final String REDIS_KEY_PREFIX = "refresh:";
 }

--- a/src/main/java/com/pickyfy/pickyfy/common/config/RedisConfig.java
+++ b/src/main/java/com/pickyfy/pickyfy/common/config/RedisConfig.java
@@ -1,12 +1,29 @@
 package com.pickyfy.pickyfy.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.pickyfy.pickyfy.common.Constant;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
+@EnableCaching
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")
@@ -18,5 +35,29 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        RedisSerializer<Object> jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+        RedisSerializer<String> stringSerializer = new StringRedisSerializer();
+
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(stringSerializer))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer));
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+        cacheConfigurations.put("magazines", defaultConfig.entryTtl(Duration.ofMillis(Constant.MAGAZINES_EXPIRATION_TIME)));
+        cacheConfigurations.put("categories", defaultConfig.entryTtl(Duration.ofMillis(Constant.CATEGORIES_EXPIRATION_TIME)));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultConfig)
+                .withInitialCacheConfigurations(cacheConfigurations)
+                .build();
     }
 }

--- a/src/main/java/com/pickyfy/pickyfy/common/config/RedisConfig.java
+++ b/src/main/java/com/pickyfy/pickyfy/common/config/RedisConfig.java
@@ -7,7 +7,6 @@ import com.pickyfy.pickyfy.common.Constant;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.transaction.TransactionAwareCacheManagerProxy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -53,6 +52,7 @@ public class RedisConfig {
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer));
 
         Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+        cacheConfigurations.put("place", defaultConfig.entryTtl(Duration.ofMillis(Constant.PLACE_EXPIRATION_TIME)));
         cacheConfigurations.put("places", defaultConfig.entryTtl(Duration.ofMillis(Constant.PLACES_EXPIRATION_TIME)));
         cacheConfigurations.put("magazines", defaultConfig.entryTtl(Duration.ofMillis(Constant.MAGAZINES_EXPIRATION_TIME)));
         cacheConfigurations.put("categories", defaultConfig.entryTtl(Duration.ofMillis(Constant.CATEGORIES_EXPIRATION_TIME)));

--- a/src/main/java/com/pickyfy/pickyfy/common/config/RedisConfig.java
+++ b/src/main/java/com/pickyfy/pickyfy/common/config/RedisConfig.java
@@ -7,6 +7,7 @@ import com.pickyfy.pickyfy.common.Constant;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.transaction.TransactionAwareCacheManagerProxy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -52,6 +53,7 @@ public class RedisConfig {
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer));
 
         Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+        cacheConfigurations.put("places", defaultConfig.entryTtl(Duration.ofMillis(Constant.PLACES_EXPIRATION_TIME)));
         cacheConfigurations.put("magazines", defaultConfig.entryTtl(Duration.ofMillis(Constant.MAGAZINES_EXPIRATION_TIME)));
         cacheConfigurations.put("categories", defaultConfig.entryTtl(Duration.ofMillis(Constant.CATEGORIES_EXPIRATION_TIME)));
 

--- a/src/main/java/com/pickyfy/pickyfy/common/config/RedisConfig.java
+++ b/src/main/java/com/pickyfy/pickyfy/common/config/RedisConfig.java
@@ -7,6 +7,7 @@ import com.pickyfy.pickyfy.common.Constant;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.transaction.TransactionAwareCacheManagerProxy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -57,9 +58,11 @@ public class RedisConfig {
         cacheConfigurations.put("magazines", defaultConfig.entryTtl(Duration.ofMillis(Constant.MAGAZINES_EXPIRATION_TIME)));
         cacheConfigurations.put("categories", defaultConfig.entryTtl(Duration.ofMillis(Constant.CATEGORIES_EXPIRATION_TIME)));
 
-        return RedisCacheManager.builder(connectionFactory)
+        RedisCacheManager manager = RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(defaultConfig)
                 .withInitialCacheConfigurations(cacheConfigurations)
                 .build();
+
+        return new TransactionAwareCacheManagerProxy(manager);
     }
 }

--- a/src/main/java/com/pickyfy/pickyfy/common/util/RedisUtil.java
+++ b/src/main/java/com/pickyfy/pickyfy/common/util/RedisUtil.java
@@ -16,26 +16,24 @@ public class RedisUtil {
 
     private final StringRedisTemplate stringRedisTemplate;
 
-    public void setDataExpire(String key, String value, long duration) {
-        try {
-            ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
-            Duration expireDuration = Duration.ofMillis(duration);
-            valueOperations.set(key, value, expireDuration);
-        }catch(DataAccessException e){
-            throw new ExceptionHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    public String getData(String key){
+    public String getData(String key) {
         try {
             ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
             return valueOperations.get(key);
-        } catch(DataAccessException e){
+        } catch (DataAccessException e) {
             throw new ExceptionHandler(ErrorStatus.KEY_NOT_FOUNT);
         }
     }
 
-    public void deleteRefreshToken(String redisKey) {
+    public void setData(String key, String value, long duration) {
+        try {
+            ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+            valueOperations.set(key, value, Duration.ofMillis(duration));
+        } catch (DataAccessException e) {
+            throw new ExceptionHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+    }
+    public void deleteData(String redisKey) {
         try {
             stringRedisTemplate.delete(redisKey);
         } catch (DataAccessException e) {

--- a/src/main/java/com/pickyfy/pickyfy/service/AuthServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/AuthServiceImpl.java
@@ -18,7 +18,7 @@ public class AuthServiceImpl implements AuthService{
 
     @Override
     public void logout(String refreshToken){
-        redisUtil.deleteRefreshToken(Constant.REDIS_KEY_PREFIX + jwtUtil.getPrincipal(refreshToken));
+        redisUtil.deleteData(Constant.REDIS_KEY_PREFIX + jwtUtil.getPrincipal(refreshToken));
     }
 
     @Override
@@ -28,7 +28,7 @@ public class AuthServiceImpl implements AuthService{
         String accessToken = jwtUtil.createAccessToken(principal, jwtUtil.getRole(token));
         String refreshToken = jwtUtil.createRefreshToken(principal, jwtUtil.getRole(token));
 
-        redisUtil.setDataExpire("refresh:" + jwtUtil.getPrincipal(refreshToken), refreshToken, Constant.REFRESH_TOKEN_EXPIRATION_TIME);
+        redisUtil.setData("refresh:" + jwtUtil.getPrincipal(refreshToken), refreshToken, Constant.REFRESH_TOKEN_EXPIRATION_TIME);
         return AuthResponse.from(accessToken, refreshToken);
     }
 

--- a/src/main/java/com/pickyfy/pickyfy/service/CategoryServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/CategoryServiceImpl.java
@@ -11,6 +11,7 @@ import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,11 +41,13 @@ public class CategoryServiceImpl implements CategoryService {
     }
 
     @Override
+    @Cacheable(value = "categories", key = "'all'", unless = "#result.isEmpty()")
     public List<CategoryResponse> getAllCategories() {
         return categoryRepository.findAll().stream()
                 .map(CategoryResponse::from)
                 .collect(Collectors.toList());
     }
+
 
     @Override
     @Transactional

--- a/src/main/java/com/pickyfy/pickyfy/service/EmailServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/EmailServiceImpl.java
@@ -68,7 +68,7 @@ public class EmailServiceImpl implements EmailService {
             throw new ExceptionHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
         }
 
-        redisUtil.setDataExpire("email:" + email, code, Constant.EMAIL_TOKEN_EXPIRATION_TIME);
+        redisUtil.setData("email:" + email, code, Constant.EMAIL_TOKEN_EXPIRATION_TIME);
     }
 
     private MimeMessage createMimeMessage(String code, String email) throws MessagingException {

--- a/src/main/java/com/pickyfy/pickyfy/service/MagazineServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/MagazineServiceImpl.java
@@ -41,7 +41,7 @@ public class MagazineServiceImpl implements MagazineService {
     }
 
     @Override
-    @Cacheable(value = "categories", key = "'all'", unless = "#result.isEmpty()")
+    @Cacheable(value = "magazines", key = "'all'", unless = "#result.isEmpty()")
     public List<MagazineResponse> getAllMagazines() {
         return magazineRepository.findAll().stream()
                 .map(MagazineResponse::from)

--- a/src/main/java/com/pickyfy/pickyfy/service/MagazineServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/MagazineServiceImpl.java
@@ -10,6 +10,7 @@ import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +41,7 @@ public class MagazineServiceImpl implements MagazineService {
     }
 
     @Override
+    @Cacheable(value = "categories", key = "'all'", unless = "#result.isEmpty()")
     public List<MagazineResponse> getAllMagazines() {
         return magazineRepository.findAll().stream()
                 .map(MagazineResponse::from)

--- a/src/main/java/com/pickyfy/pickyfy/service/PlaceServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/PlaceServiceImpl.java
@@ -44,6 +44,7 @@ public class PlaceServiceImpl implements PlaceService {
      * 특정 유저가 저장한 Place 전체 조회
      */
     @Override
+    @Cacheable(value = "place", key = "#email", unless = "#result.isEmpty()")
     public List<PlaceSearchResponse> getUserSavePlace(String email) {
         // 유저 조회
         User user = findUserByEmail(email);
@@ -93,6 +94,7 @@ public class PlaceServiceImpl implements PlaceService {
      */
     @Override
     @Transactional
+    @CacheEvict(value = "place", key = "#email")
     public boolean togglePlaceUser(String email, Long placeId) {
         Place place = findPlaceById(placeId);
         User user = findUserByEmail(email);

--- a/src/main/java/com/pickyfy/pickyfy/service/PlaceServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/PlaceServiceImpl.java
@@ -16,6 +16,8 @@ import jakarta.persistence.EntityNotFoundException;
 import java.util.*;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -89,6 +91,7 @@ public class PlaceServiceImpl implements PlaceService {
     /**
      * 유저 Place 저장 및 저장취소 (toggle)
      */
+    @Override
     @Transactional
     public boolean togglePlaceUser(String email, Long placeId) {
         Place place = findPlaceById(placeId);
@@ -114,6 +117,7 @@ public class PlaceServiceImpl implements PlaceService {
     }
 
     @Transactional
+    @CacheEvict(value = "places", key = "'all'")
     public Long createPlace(PlaceCreateRequest request, List<MultipartFile> imageList) {
         if (placeRepository.existsPlaceByName(request.name())) {
             throw new EntityExistsException(ErrorStatus.PLACE_NAME_DUPLICATED.getMessage());
@@ -150,6 +154,7 @@ public class PlaceServiceImpl implements PlaceService {
 
     @Override
     @Transactional
+    @CacheEvict(value = "places", key = "'all'")
     public Long updatePlace(Long placeId, PlaceCreateRequest request, List<MultipartFile> imageList) {
         Place place = findPlaceById(placeId);
 
@@ -162,6 +167,7 @@ public class PlaceServiceImpl implements PlaceService {
 
     @Override
     @Transactional
+    @CacheEvict(value = "places", key = "'all'")
     public void deletePlace(Long placeId) {
         Place place = findPlaceById(placeId);
         for (PlaceImage image : place.getPlaceImages()) {
@@ -172,6 +178,7 @@ public class PlaceServiceImpl implements PlaceService {
 
     @Override
     @Transactional(readOnly = true)
+    @Cacheable(value = "places", key = "'all'", unless = "#result.isEmpty()")
     public List<PlaceSearchResponse> getAllPlaces() {
         List<Place> allPlaceList = placeRepository.findAll();
         return allPlaceList.stream()

--- a/src/main/java/com/pickyfy/pickyfy/service/UserServiceImpl.java
+++ b/src/main/java/com/pickyfy/pickyfy/service/UserServiceImpl.java
@@ -84,7 +84,7 @@ public class UserServiceImpl implements UserService {
     }
 
     private void invalidateTokens(String userEmail){
-        redisUtil.deleteRefreshToken(Constant.REDIS_KEY_PREFIX + userEmail);
+        redisUtil.deleteData(Constant.REDIS_KEY_PREFIX + userEmail);
     }
 
     private void validateEmailToken(String email, String token){


### PR DESCRIPTION
## #️⃣연관된 이슈

> #97 

## 📝작업 내용

> Redis를 사용해 캐싱 구현

Util(service) class를 통해 캐싱을 제어할지 아니면 @Cacheable @CacheEvict과 같은 어노테이션을 사용하여 캐싱을 할지 고민했다.

Util로 관리하면 일관성이 유지되고 TTL 설정, 데이터 삭제 등도 직접 제어할 수 있어 관리 측면에서 일관성이 있고 정책을 직접 조정할 수 있는 점에서 유지보수가 용이하다.

어노테이션을 사용하면 단순하고 빠르고 간단하게 캐싱을 적용할 수 있으며 AOP 방식으로 동작하여 비즈니스 로직과 캐싱 로직이 분리되어 코드 복잡도를 낮추고 유지보수할 코드량이 줄어든다는 점에서 유지보수가 용이하다.

-> 처음에 Util로 작성하였으나 단순한 조회 캐싱이 될 것으로 예상하여 어노테이션 방식의 캐싱을 사용하게 되었다.

최종적으로 작성하고 보니 redis 자료구조 선택의 한계로 인해 세밀한 조작이 어려워 Util로 관리하는 것이 좋을 것 같다.